### PR TITLE
Use dumpSingleDatabase for single DB dumps

### DIFF
--- a/src/lib/adapters/database/mongodb/dump.ts
+++ b/src/lib/adapters/database/mongodb/dump.ts
@@ -1,6 +1,5 @@
 import { BackupResult } from "@/lib/core/interfaces";
 import { LogLevel, LogType } from "@/lib/core/logs";
-import { getDialect } from "./dialects";
 import { spawn } from "child_process";
 import { createWriteStream } from "fs";
 import { waitForProcess } from "@/lib/adapters/process";
@@ -203,37 +202,10 @@ export async function dump(
             }
         }
 
-        const dialect = getDialect('mongodb', config.detectedVersion);
-
         // Case 1: Single Database or ALL - Direct archive dump
         if (dbs.length <= 1) {
-            const args = dialect.getDumpArgs(config, dbs);
-
-            // Mask password in logs
-            const logArgs = args.map(arg => {
-                if (arg.startsWith('--password')) return '--password=******';
-                if (arg.startsWith('mongodb')) return 'mongodb://...';
-                return arg;
-            });
-
-            log(`Running mongo dump`, 'info', 'command', `mongodump ${logArgs.join(' ')}`);
-
-            const dumpProcess = spawn('mongodump', args);
-            const writeStream = createWriteStream(destinationPath);
-            const stderrLines: string[] = [];
-
-            dumpProcess.stdout.pipe(writeStream);
-
-            dumpProcess.stderr.on('data', (data) => {
-                const msg = data.toString().trim();
-                if (msg) stderrLines.push(msg);
-            });
-
-            await waitForProcess(dumpProcess, 'mongodump');
-
-            if (stderrLines.length > 0) {
-                log(`mongodump output`, 'info', 'command', stderrLines.join('\n'));
-            }
+            log(`Starting single-database dump (archive format)`, 'info');
+            await dumpSingleDatabase(dbs[0] || '', destinationPath, config, log);
         }
         // Case 2: Multiple Databases - TAR archive with individual mongodump per DB
         else {

--- a/src/lib/adapters/database/postgres/dump.ts
+++ b/src/lib/adapters/database/postgres/dump.ts
@@ -1,6 +1,5 @@
 import { BackupResult } from "@/lib/core/interfaces";
 import { LogLevel, LogType } from "@/lib/core/logs";
-import { getDialect } from "./dialects";
 import { spawn } from "child_process";
 import fs from "fs/promises";
 import { createWriteStream } from "fs";
@@ -208,34 +207,10 @@ export async function dump(
             }
         }
 
-        const dialect = getDialect('postgres', config.detectedVersion);
-
         // Case 1: Single Database - Direct dump with custom format
         if (dbs.length <= 1) {
-            const args = dialect.getDumpArgs(config, dbs);
-
-            log(`Starting single-database dump (custom format)`, 'info', 'command', `pg_dump ${args.join(' ')}`);
-
-            const dumpProcess = spawn('pg_dump', args, { env });
-            const writeStream = createWriteStream(destinationPath);
-
-            dumpProcess.stdout.pipe(writeStream);
-
-            dumpProcess.stderr.on('data', (data) => {
-                const msg = data.toString().trim();
-                if (msg && !msg.includes('NOTICE:')) {
-                    log(msg, 'info');
-                }
-            });
-
-            await new Promise<void>((resolve, reject) => {
-                dumpProcess.on('close', (code) => {
-                    if (code === 0) resolve();
-                    else reject(new Error(`pg_dump exited with code ${code}`));
-                });
-                dumpProcess.on('error', (err) => reject(err));
-                writeStream.on('error', (err) => reject(err));
-            });
+            log(`Starting single-database dump (custom format)`, 'info');
+            await dumpSingleDatabase(dbs[0], destinationPath, config, env, log);
         }
         // Case 2: Multiple Databases - TAR archive with individual pg_dump per DB
         else {

--- a/wiki/changelog.md
+++ b/wiki/changelog.md
@@ -2,6 +2,20 @@
 
 All notable changes to DBackup are documented here.
 
+## v1.4.5 - SSH Backup Fixes with single database selection
+*Released: April 19, 2026*
+
+### 🐛 Bug Fixes
+
+- **postgres**: Fixed single-database backups via SSH running `pg_dump` locally instead of on the remote server, causing "Connection refused" errors (#22)
+- **mongodb**: Fixed same SSH bypass bug for single-database `mongodump` backups
+
+### 🐳 Docker
+
+- **Image**: `skyfay/dbackup:v1.4.5`
+- **Also tagged as**: `latest`, `v1`
+- **Platforms**: linux/amd64, linux/arm64
+
 ## v1.4.4 - HTTPS Redirect Loop Fix
 *Released: April 18, 2026*
 


### PR DESCRIPTION
Replace in-file single-database dump logic with calls to the shared dumpSingleDatabase helper in both MongoDB and Postgres adapters, and remove unused getDialect imports. This centralizes and simplifies single-DB dump behavior (archive/custom format) and fixes SSH-related single-db backup issues where dumps were executed locally.

This will fix the issue #22 