### PR TITLE
Add issue templates and update to version 1.4.6 with TAR extension change

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: DBackup Version
+      description: Which version of DBackup are you running?
+      placeholder: e.g. v1.4.6
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation Method
+      options:
+        - Docker (docker-compose)
+        - Docker (standalone)
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Output
+      description: Paste any relevant logs or error messages. Use the execution detail view for backup/restore errors.
+      render: shell
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any additional environment details.
+      placeholder: |
+        - OS: Ubuntu 24.04
+        - Docker: 27.x
+        - Database: PostgreSQL 16
+        - Browser: Firefox 128

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Wiki / Documentation
+    url: https://dbackup.app
+    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,44 @@
+name: Documentation Issue
+description: Report missing, incorrect, or unclear documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found an issue with the documentation? Let us know so we can improve it.
+
+  - type: input
+    id: page
+    attributes:
+      label: Page / Section
+      description: Which documentation page or section is affected?
+      placeholder: e.g. User Guide > Getting Started
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Issue Type
+      options:
+        - Missing documentation
+        - Incorrect / outdated information
+        - Unclear / confusing explanation
+        - Typo / formatting
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is wrong or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: How should the documentation be improved?

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,58 @@
+name: Enhancement
+description: Suggest an improvement to an existing feature
+title: "[Enhancement]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Want to improve something that already exists in DBackup? Let us know what could be better.
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behavior
+      description: How does the existing feature currently work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: improvement
+    attributes:
+      label: Proposed Improvement
+      description: How should it work instead? What would you change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why would this improvement be useful?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of DBackup does this relate to?
+      options:
+        - Backup / Restore
+        - Database Adapters
+        - Storage Adapters
+        - Notifications
+        - UI / Dashboard
+        - Authentication / SSO
+        - Scheduling / Cron
+        - API
+        - Docker / Deployment
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or mockups.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,57 @@
+name: Feature Request
+description: Suggest a completely new feature that doesn't exist yet
+title: "[Feature Request]: "
+labels: ["feature request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new feature in DBackup? Please describe what you'd like to see added.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of DBackup does this relate to?
+      options:
+        - Backup / Restore
+        - Database Adapters
+        - Storage Adapters
+        - Notifications
+        - UI / Dashboard
+        - Authentication / SSO
+        - Scheduling / Cron
+        - API
+        - Docker / Deployment
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or mockups.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,30 @@
+name: Question / Support
+description: Ask a question about setup, configuration, or usage
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about DBackup? Check the [documentation](https://dbackup.skyfay.dev) first - your answer might already be there.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: DBackup Version
+      description: Which version are you running? (optional)
+      placeholder: e.g. v1.4.6
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any relevant details, screenshots, or configuration snippets.

--- a/api-docs/openapi.yaml
+++ b/api-docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: DBackup API
-  version: 1.4.4
+  version: 1.4.6
   description: |
     REST API for DBackup - a self-hosted database backup automation platform with encryption, compression, and smart retention.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbackup",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: DBackup API
-  version: 1.4.4
+  version: 1.4.6
   description: |
     REST API for DBackup - a self-hosted database backup automation platform with encryption, compression, and smart retention.
 

--- a/src/lib/runner/steps/02-dump.ts
+++ b/src/lib/runner/steps/02-dump.ts
@@ -253,6 +253,14 @@ export async function stepExecuteDump(ctx: RunnerContext) {
                     }
                 };
                 ctx.log(`Multi-DB TAR archive detected: ${manifest.databases.length} databases`);
+
+                // Rename file to .tar extension to reflect actual format
+                if (!dumpPath.endsWith('.tar')) {
+                    const tarPath = dumpPath.replace(/\.[^.]+$/, '.tar');
+                    await fs.rename(dumpPath, tarPath);
+                    ctx.tempFile = tarPath;
+                    ctx.log(`Renamed backup file to .tar extension: ${path.basename(tarPath)}`);
+                }
             }
         }
     } catch (e: unknown) {

--- a/wiki/changelog.md
+++ b/wiki/changelog.md
@@ -2,8 +2,8 @@
 
 All notable changes to DBackup are documented here.
 
-## v1.4.6
-*Release: In Progress*
+## v1.4.6 - Issue Templates and extension corrections
+*Released: April 19, 2026*
 
 ### 🔄 Changed
 

--- a/wiki/changelog.md
+++ b/wiki/changelog.md
@@ -2,6 +2,20 @@
 
 All notable changes to DBackup are documented here.
 
+## v1.4.6
+*Release: In Progress*
+
+### � CI/CD
+
+- **github**: Added GitHub Issue templates for Bug Reports, Feature Requests, Questions/Support, and Documentation Issues
+
+### �🐳 Docker
+
+- **Image**: `skyfay/dbackup:v1.4.6`
+- **Also tagged as**: `latest`, `v1`
+- **Platforms**: linux/amd64, linux/arm64
+
+
 ## v1.4.5 - SSH Backup Fixes with single database selection
 *Released: April 19, 2026*
 

--- a/wiki/changelog.md
+++ b/wiki/changelog.md
@@ -5,11 +5,15 @@ All notable changes to DBackup are documented here.
 ## v1.4.6
 *Release: In Progress*
 
-### � CI/CD
+### 🔄 Changed
+
+- **backup**: Multi-database backups now use `.tar` file extension instead of the adapter-specific extension (e.g. `.sql`), correctly reflecting the TAR archive format (#25)
+
+### 🔧 CI/CD
 
 - **github**: Added GitHub Issue templates for Bug Reports, Feature Requests, Questions/Support, and Documentation Issues
 
-### �🐳 Docker
+###  🐳 Docker
 
 - **Image**: `skyfay/dbackup:v1.4.6`
 - **Also tagged as**: `latest`, `v1`

--- a/wiki/package.json
+++ b/wiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbackup-wiki",
-  "version": "1.4.4",
+  "version": "1.4.6",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",


### PR DESCRIPTION
**Issue Reporting Improvements:**

* Added new GitHub Issue templates for bug reports, feature requests, enhancements, questions/support, and documentation issues in the `.github/ISSUE_TEMPLATE` directory, making it easier for users to provide structured feedback and requests. [[1]](diffhunk://#diff-7c49a365610d935ce439e3f241cd3f5d1df89a95d1a674d11ebdb1e518c7335cR1-R81) [[2]](diffhunk://#diff-a18ac139672d9f557f950ebe7df3f057ba19abe40d02ac2c81f72bcf44257b68R1-R57) [[3]](diffhunk://#diff-e4c10e275fca255d4f8c81d9118c0c986bd3a17726db54f154f7d94b56489d12R1-R58) [[4]](diffhunk://#diff-2e008196bfac9fc9e304318a87047829d828073ddf26962d120005e7990a179bR1-R44) [[5]](diffhunk://#diff-b6087b0ddc2695a819e8199639ea5be88e1352a9a10774c7183eefa682e2dc76R1-R30)
* Updated `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and add a documentation contact link.

**Backup File Handling:**

* Modified the backup step for multi-database backups to automatically rename the backup file to use a `.tar` extension, accurately reflecting the TAR archive format instead of the adapter-specific extension #25