### PR TITLE
chore: add OCI standard labels to Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          labels: |
+            org.opencontainers.image.description=A self-hosted database backup automation tool for MySQL, PostgreSQL, MongoDB & more. Backup to S3, FTP, or Local Storage.
+            org.opencontainers.image.vendor=Skyfay
+            org.opencontainers.image.licenses=GPL-3.0-only
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -65,6 +77,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ env.GHCR_IMAGE }}:${{ github.ref_name }}-${{ matrix.suffix }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=build-${{ matrix.suffix }}
           cache-to: type=gha,scope=build-${{ matrix.suffix }},mode=max
 


### PR DESCRIPTION
## Context

Add [OCI (Open Container Initiative)](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to the Docker image for better registry compatibility and dependency bot integration.

## Type

Improvement — metadata only, no functional changes.

## Labels Added

| Label | Value | Source |
|-------|-------|--------|
| `org.opencontainers.image.title` | `dbackup` | Auto (image name via metadata-action) |
| `org.opencontainers.image.description` | `A self-hosted database backup automation tool…` | Custom label |
| `org.opencontainers.image.url` | `https://github.com/Skyfay/dbackup` | Auto (GitHub context) |
| `org.opencontainers.image.source` | `https://github.com/Skyfay/dbackup` | Auto (GitHub context) |
| `org.opencontainers.image.licenses` | `GPL-3.0-only` | Custom label |
| `org.opencontainers.image.vendor` | `Skyfay` | Custom label |
| `org.opencontainers.image.version` | Tag name (e.g. `v1.4.4`) | Auto (git tag) |
| `org.opencontainers.image.revision` | Git commit SHA | Auto (git context) |
| `org.opencontainers.image.created` | Build timestamp (RFC 3339) | Auto (build time) |

## Benefits

- **Registry compatibility**: GHCR and Docker Hub display these labels in their web UI (description, license, source link)
- **Dependency bot changelogs**: Renovate and Dependabot use `org.opencontainers.image.source` to locate and display release notes directly in update PRs
- **Image provenance**: `revision` + `created` enable precise build auditing and security scanning (Trivy, Grype)
- **Standardization**: Follows OCI Image Spec best practices

## Changes

Added `docker/metadata-action@v5` step to the `build` job in `.github/workflows/release.yml`. The action auto-generates all standard OCI labels from GitHub context (title, url, source, version, revision, created). Three custom labels are passed explicitly for values the action cannot infer: `description`, `vendor`, and `licenses`. The generated labels are then wired to `docker/build-push-action` via `labels: ${{ steps.meta.outputs.labels }}`.

No Dockerfile changes needed — labels are injected entirely at the CI layer.

## References

- [OCI Image Spec — Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [docker/metadata-action](https://github.com/docker/metadata-action)
- [Docker — Manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)