### PR TITLE
fix: use BETTER_AUTH_URL for Google Drive OAuth redirect URIs

### DIFF
--- a/src/app/api/adapters/google-drive/auth/route.ts
+++ b/src/app/api/adapters/google-drive/auth/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: NextRequest) {
         }
 
         // Build callback URL from the request origin
-        const origin = req.nextUrl.origin;
+        const origin = process.env.BETTER_AUTH_URL || req.nextUrl.origin;
         const redirectUri = `${origin}/api/adapters/google-drive/callback`;
 
         const oauth2Client = new google.auth.OAuth2(

--- a/src/app/api/adapters/google-drive/callback/route.ts
+++ b/src/app/api/adapters/google-drive/callback/route.ts
@@ -15,7 +15,7 @@ const log = logger.child({ route: "adapters/google-drive/callback" });
  * Redirects back to the destinations page with success/error status.
  */
 export async function GET(req: NextRequest) {
-    const origin = req.nextUrl.origin;
+    const origin = process.env.BETTER_AUTH_URL || req.nextUrl.origin;
 
     // Verify the user is authenticated before processing the OAuth callback
     const session = await auth.api.getSession({ headers: await headers() });


### PR DESCRIPTION
## Problem
When DBackup is deployed behind a reverse proxy, the Google Drive OAuth 
flow fails with Error 400: invalid_request because the redirect_uri sent 
to Google is built using `request.nextUrl.origin`, which resolves to 
`https://0.0.0.0:3000` internally instead of the public-facing domain.

## Root Cause
Two files in the Google Drive adapter use `req.nextUrl.origin` to build 
URLs instead of `BETTER_AUTH_URL`:

1. `src/app/api/adapters/google-drive/auth/route.ts` — builds the OAuth redirect_uri
2. `src/app/api/adapters/google-drive/callback/route.ts` — builds both the 
   redirect_uri for token exchange and the post-auth dashboard redirect

## Fix
Replace `req.nextUrl.origin` with `process.env.BETTER_AUTH_URL || req.nextUrl.origin` 
in both files. This ensures the correct public URL is used when BETTER_AUTH_URL 
is set, while falling back to the request origin for local development.

## Testing
- Deployed behind Caddy reverse proxy with DISABLE_HTTPS=true
- BETTER_AUTH_URL=https://my-domain.com
- Google OAuth flow now completes successfully
- Post-auth redirect correctly goes to the public domain

## Notes
The same issue likely affects the Dropbox and OneDrive adapters 
as they appear to use the same pattern.