### PR TITLE
feat: Agregar soporte de timezone y patrones personalizados para nomb…

### DIFF
--- a/src/app/actions/settings.ts
+++ b/src/app/actions/settings.ts
@@ -7,6 +7,7 @@ import { checkPermission } from "@/lib/access-control";
 import { PERMISSIONS } from "@/lib/permissions";
 import { logger } from "@/lib/logger";
 import { wrapError } from "@/lib/errors";
+import { scheduler } from "@/lib/scheduler";
 
 const log = logger.child({ action: "settings" });
 
@@ -19,6 +20,13 @@ const settingsSchema = z.object({
     notificationLogRetentionDays: z.coerce.number().min(7).max(1825).optional(),
     checkForUpdates: z.boolean().optional(),
     showQuickSetup: z.boolean().optional(),
+    systemTimezone: z.string()
+        .refine((tz) => {
+            try { return Intl.supportedValuesOf('timeZone').includes(tz) || tz === 'UTC'; }
+            catch { return false; }
+        }, { message: "Invalid IANA timezone" })
+        .optional(),
+    filenamePattern: z.string().min(1).optional(),
 });
 
 export async function updateSystemSettings(data: z.infer<typeof settingsSchema>) {
@@ -98,6 +106,27 @@ export async function updateSystemSettings(data: z.infer<typeof settingsSchema>)
                create: { key: "general.showQuickSetup", value: String(result.data.showQuickSetup) },
            });
        }
+
+        // System Timezone Setting (default UTC)
+        if (result.data.systemTimezone !== undefined) {
+            await prisma.systemSetting.upsert({
+                where: { key: "system.timezone" },
+                update: { value: result.data.systemTimezone },
+                create: { key: "system.timezone", value: result.data.systemTimezone, description: "System-wide timezone for scheduler" },
+            });
+
+            // Refresh scheduler to apply new timezone to all cron tasks
+            scheduler.refresh().catch((e) => log.error("Scheduler refresh failed after timezone update", {}, wrapError(e)));
+        }
+
+        // Backup Filename Pattern Setting
+        if (result.data.filenamePattern !== undefined) {
+            await prisma.systemSetting.upsert({
+                where: { key: "system.filenamePattern" },
+                update: { value: result.data.filenamePattern },
+                create: { key: "system.filenamePattern", value: result.data.filenamePattern, description: "Template pattern for backup file names" },
+            });
+        }
 
         revalidatePath("/dashboard/settings");
         return { success: true };

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -13,18 +13,27 @@ export async function GET(_req: NextRequest) {
     try {
         checkPermissionWithContext(ctx, PERMISSIONS.HISTORY.READ);
 
-        const executions = await prisma.execution.findMany({
-            include: {
-                job: {
-                    select: {
-                        name: true,
+        const [executions, tzSetting] = await Promise.all([
+            prisma.execution.findMany({
+                include: {
+                    job: {
+                        select: {
+                            name: true,
+                        }
                     }
-                }
-            },
-            orderBy: { startedAt: 'desc' },
-            take: 100
+                },
+                orderBy: { startedAt: 'desc' },
+                take: 100
+            }),
+            prisma.systemSetting.findUnique({ where: { key: "system.timezone" } })
+        ]);
+
+        const systemTimezone = tzSetting?.value || "UTC";
+
+        return NextResponse.json({
+            executions,
+            systemTimezone
         });
-        return NextResponse.json(executions);
     } catch (_error) {
         return NextResponse.json({ error: "Failed to fetch history" }, { status: 500 });
     }

--- a/src/app/dashboard/history/columns.tsx
+++ b/src/app/dashboard/history/columns.tsx
@@ -22,7 +22,7 @@ export interface Execution {
     metadata?: string;
 }
 
-export const createColumns = (onViewLogs: (execution: Execution) => void): ColumnDef<Execution>[] => [
+export const createColumns = (onViewLogs: (execution: Execution) => void, systemTimezone: string = "UTC"): ColumnDef<Execution>[] => [
     {
         id: "jobName",
         accessorFn: (row) => row.job?.name || "Manual Action",
@@ -96,7 +96,7 @@ export const createColumns = (onViewLogs: (execution: Execution) => void): Colum
         accessorKey: "startedAt",
         header: "Started At",
         cell: ({ row }) => {
-             return <DateDisplay date={row.getValue("startedAt")} format="PPpp" />;
+             return <DateDisplay date={row.getValue("startedAt")} format="PPpp" timezone={systemTimezone} />;
         }
     },
     {

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -31,6 +31,7 @@ export default function HistoryPage() {
 
 function HistoryContent() {
     const [executions, setExecutions] = useState<Execution[]>([]);
+    const [systemTimezone, setSystemTimezone] = useState("UTC");
     const [selectedLog, setSelectedLog] = useState<Execution | null>(null);
     const [activeTab, setActiveTab] = useState("activity");
 
@@ -76,7 +77,11 @@ function HistoryContent() {
         fetchInFlight.current = true;
         try {
             const res = await fetch("/api/history");
-            if (res.ok) setExecutions(await res.json());
+            if (res.ok) {
+                const data = await res.json();
+                setExecutions(data.executions);
+                setSystemTimezone(data.systemTimezone);
+            }
         } catch (_e) {
             console.error(_e);
         } finally {
@@ -145,7 +150,7 @@ function HistoryContent() {
         }
     }, [fetchHistory]);
 
-    const columns = useMemo(() => createColumns(setSelectedLog), []);
+    const columns = useMemo(() => createColumns(setSelectedLog, systemTimezone), [systemTimezone]);
     const notificationColumns = useMemo(
         () => createNotificationLogColumns(setSelectedNotification),
         []
@@ -284,7 +289,7 @@ function HistoryContent() {
                              )}
                         </DialogTitle>
                         <DialogDescription className="text-muted-foreground">
-                            {selectedLog?.startedAt && <DateDisplay date={selectedLog.startedAt} format="PPpp" />}
+                            {selectedLog?.startedAt && <DateDisplay date={selectedLog.startedAt} format="PPpp" timezone={systemTimezone} />}
                         </DialogDescription>
                     </DialogHeader>
 
@@ -328,6 +333,7 @@ function HistoryContent() {
                             logs={selectedLog ? parseLogs(selectedLog.logs) : []}
                             status={selectedLog?.status}
                             executionType={selectedLog?.type}
+                            systemTimezone={systemTimezone}
                             className="h-full border-0 bg-transparent"
                          />
                     </div>

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -53,6 +53,12 @@ export default async function SettingsPage() {
     const quickSetupSetting = await prisma.systemSetting.findUnique({ where: { key: "general.showQuickSetup" } });
     const showQuickSetup = quickSetupSetting?.value === 'true';
 
+    const timezoneSetting = await prisma.systemSetting.findUnique({ where: { key: "system.timezone" } });
+    const systemTimezone = timezoneSetting?.value || "UTC";
+
+    const patternSetting = await prisma.systemSetting.findUnique({ where: { key: "system.filenamePattern" } });
+    const filenamePattern = patternSetting?.value || "{name}_yyyy-MM-dd_HH-mm-ss";
+
     // Load Config Backup Settings
     const configEnabled = await prisma.systemSetting.findUnique({ where: { key: "config.backup.enabled" } });
     const configSchedule = await prisma.systemSetting.findUnique({ where: { key: "config.backup.schedule" } });
@@ -114,6 +120,8 @@ export default async function SettingsPage() {
                         initialNotificationLogRetentionDays={notificationLogRetentionDays}
                         initialCheckForUpdates={checkForUpdates}
                         initialShowQuickSetup={showQuickSetup}
+                        initialSystemTimezone={systemTimezone}
+                        initialFilenamePattern={filenamePattern}
                     />
                 </TabsContent>
                 <TabsContent value="notifications" className="space-y-4">

--- a/src/components/execution/log-viewer.tsx
+++ b/src/components/execution/log-viewer.tsx
@@ -29,6 +29,7 @@ interface LogViewerProps {
   autoScroll?: boolean;
   status?: string; // Overall job status
   executionType?: string; // "Backup" | "Restore"
+  systemTimezone?: string; // System timezone for timestamps
 }
 
 interface LogGroup {
@@ -40,7 +41,7 @@ interface LogGroup {
     durationMs?: number;
 }
 
-export function LogViewer({ logs, className, autoScroll = true, status, executionType }: LogViewerProps) {
+export function LogViewer({ logs, className, autoScroll = true, status, executionType, systemTimezone = "UTC" }: LogViewerProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [shouldAutoScroll, setShouldAutoScroll] = useState(autoScroll);
   const [activeStages, setActiveStages] = useState<string[]>([]);
@@ -243,7 +244,7 @@ export function LogViewer({ logs, className, autoScroll = true, status, executio
                         <AccordionContent className="pt-2 pb-4 px-2 border-t border-border/50">
                              <div className="space-y-1 pl-2 border-l border-border ml-2">
                                 {group.logs.map((log, idx) => (
-                                    <LogItem key={`${log.timestamp}-${idx}`} entry={log} />
+                                    <LogItem key={`${log.timestamp}-${idx}`} entry={log} systemTimezone={systemTimezone} />
                                 ))}
                              </div>
                         </AccordionContent>
@@ -267,7 +268,7 @@ export function LogViewer({ logs, className, autoScroll = true, status, executio
   );
 }
 
-function LogItem({ entry }: { entry: LogEntry }) {
+function LogItem({ entry, systemTimezone = "UTC" }: { entry: LogEntry; systemTimezone?: string }) {
   const [isOpen, setIsOpen] = React.useState(false);
   const hasDetails = !!entry.details || !!entry.context;
   const isCommand = entry.type === "command";
@@ -291,7 +292,7 @@ function LogItem({ entry }: { entry: LogEntry }) {
       <div className="flex items-start gap-3 py-1">
         {/* Timestamp */}
         <div className="shrink-0 text-xs text-muted-foreground w-20 pt-0.5 font-mono">
-           <DateDisplay date={entry.timestamp} format="pp" />
+           <DateDisplay date={entry.timestamp} format="pp" timezone={systemTimezone} />
         </div>
 
         {/* Icon & Message Container */}

--- a/src/components/settings/system-settings-form.tsx
+++ b/src/components/settings/system-settings-form.tsx
@@ -3,6 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm, useWatch } from "react-hook-form"
 import * as z from "zod"
+import { useState, useMemo } from "react"
 import {
     Form,
     FormControl,
@@ -15,11 +16,16 @@ import {
 import { toast } from "sonner"
 import { updateSystemSettings } from "@/app/actions/settings"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Shield, Cpu, Rocket, Database, ScrollText, HardDrive, Bell } from "lucide-react"
+import { Shield, Cpu, Rocket, Database, ScrollText, HardDrive, Bell, Globe, Check, ChevronsUpDown, FileText } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button"
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { format } from "date-fns"
 
 const formSchema = z.object({
     maxConcurrentJobs: z.coerce.number().min(1).max(10),
@@ -30,6 +36,8 @@ const formSchema = z.object({
     notificationLogRetentionDays: z.coerce.number().min(7).max(1825).default(90),
     checkForUpdates: z.boolean().default(true),
     showQuickSetup: z.boolean().default(false),
+    systemTimezone: z.string().default("UTC"),
+    filenamePattern: z.string().default("{name}_yyyy-MM-dd_HH-mm-ss"),
 })
 
 interface SystemSettingsFormProps {
@@ -41,9 +49,15 @@ interface SystemSettingsFormProps {
     initialNotificationLogRetentionDays?: number;
     initialCheckForUpdates?: boolean;
     initialShowQuickSetup?: boolean;
+    initialSystemTimezone?: string;
+    initialFilenamePattern?: string;
 }
 
-export function SystemSettingsForm({ initialMaxConcurrentJobs, initialDisablePasskeyLogin, initialSessionDuration = 604800, initialAuditLogRetentionDays = 90, initialStorageSnapshotRetentionDays = 90, initialNotificationLogRetentionDays = 90, initialCheckForUpdates = true, initialShowQuickSetup = false }: SystemSettingsFormProps) {
+export function SystemSettingsForm({ initialMaxConcurrentJobs, initialDisablePasskeyLogin, initialSessionDuration = 604800, initialAuditLogRetentionDays = 90, initialStorageSnapshotRetentionDays = 90, initialNotificationLogRetentionDays = 90, initialCheckForUpdates = true, initialShowQuickSetup = false, initialSystemTimezone = "UTC", initialFilenamePattern = "{name}_yyyy-MM-dd_HH-mm-ss" }: SystemSettingsFormProps) {
+    const [openTimezone, setOpenTimezone] = useState(false);
+    const timezones = Intl.supportedValuesOf('timeZone');
+    const filenameTokens = ['{name}', '{db_name}', 'yyyy', 'MM', 'dd', 'HH', 'mm', 'ss'];
+
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema) as any,
         defaultValues: {
@@ -55,8 +69,22 @@ export function SystemSettingsForm({ initialMaxConcurrentJobs, initialDisablePas
             notificationLogRetentionDays: initialNotificationLogRetentionDays,
             checkForUpdates: initialCheckForUpdates === true,
             showQuickSetup: initialShowQuickSetup === true,
+            systemTimezone: initialSystemTimezone || "UTC",
+            filenamePattern: initialFilenamePattern || "{name}_yyyy-MM-dd_HH-mm-ss",
         },
     })
+
+    const filenamePatternValue = useWatch({ control: form.control, name: "filenamePattern" });
+    const previewFilename = useMemo(() => {
+        try {
+            const previewPattern = filenamePatternValue
+                .replace('{name}', "'JobName'")
+                .replace('{db_name}', "'mydb'");
+            return format(new Date(), previewPattern);
+        } catch {
+            return "Invalid pattern";
+        }
+    }, [filenamePatternValue]);
 
     const handleAutoSave = async (field: keyof z.infer<typeof formSchema>, value: any) => {
         // Update local state immediately
@@ -288,6 +316,115 @@ export function SystemSettingsForm({ initialMaxConcurrentJobs, initialDisablePas
                                             onCheckedChange={(val) => handleAutoSave("checkForUpdates", val)}
                                         />
                                     </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <div className="flex items-center gap-2">
+                            <Globe className="h-5 w-5 text-muted-foreground" />
+                            <CardTitle>Scheduler Timezone</CardTitle>
+                        </div>
+                        <CardDescription>
+                            Timezone used for all backup job schedules. &quot;3:00 AM&quot; means 3:00 AM in this timezone.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <FormField
+                            control={form.control}
+                            name="systemTimezone"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>System Timezone</FormLabel>
+                                    <Popover open={openTimezone} onOpenChange={setOpenTimezone}>
+                                        <PopoverTrigger asChild>
+                                            <FormControl>
+                                                <Button variant="outline" role="combobox"
+                                                    className="w-full justify-between">
+                                                    {field.value || "UTC"}
+                                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                </Button>
+                                            </FormControl>
+                                        </PopoverTrigger>
+                                        <PopoverContent className="w-[300px] p-0">
+                                            <Command>
+                                                <CommandInput placeholder="Search timezone..." />
+                                                <CommandList>
+                                                    <CommandEmpty>No timezone found.</CommandEmpty>
+                                                    <CommandGroup>
+                                                        {timezones.map((tz) => (
+                                                            <CommandItem key={tz} value={tz}
+                                                                onSelect={() => {
+                                                                    handleAutoSave("systemTimezone", tz);
+                                                                    setOpenTimezone(false);
+                                                                }}>
+                                                                <Check className={cn("mr-2 h-4 w-4",
+                                                                    tz === field.value ? "opacity-100" : "opacity-0"
+                                                                )} />
+                                                                {tz}
+                                                            </CommandItem>
+                                                        ))}
+                                                    </CommandGroup>
+                                                </CommandList>
+                                            </Command>
+                                        </PopoverContent>
+                                    </Popover>
+                                    <FormDescription>
+                                        Timestamps in logs are always stored in UTC regardless of this setting.
+                                    </FormDescription>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader>
+                        <div className="flex items-center gap-2">
+                            <FileText className="h-5 w-5 text-muted-foreground" />
+                            <CardTitle>Backup File Naming</CardTitle>
+                        </div>
+                        <CardDescription>
+                            Customize how backup files are named. Use &quot;name&quot; for job name and &quot;db_name&quot; for database name.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <FormField
+                            control={form.control}
+                            name="filenamePattern"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Filename Pattern</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            {...field}
+                                            placeholder="{name}_yyyy-MM-dd_HH-mm-ss"
+                                            onBlur={(e) => handleAutoSave("filenamePattern", e.target.value)}
+                                        />
+                                    </FormControl>
+                                    <div className="flex flex-wrap gap-1 mt-2">
+                                        {filenameTokens.map(token => (
+                                            <Badge
+                                                key={token}
+                                                variant="outline"
+                                                className="cursor-pointer hover:bg-muted"
+                                                onClick={() => {
+                                                    const current = field.value || "";
+                                                    form.setValue("filenamePattern", current + token);
+                                                }}
+                                            >
+                                                {token}
+                                            </Badge>
+                                        ))}
+                                    </div>
+                                    <FormDescription>
+                                        Preview: <code className="bg-muted px-2 py-1 rounded text-xs">{previewFilename}.sql</code>
+                                    </FormDescription>
+                                    <FormMessage />
                                 </FormItem>
                             )}
                         />

--- a/src/components/utils/date-display.tsx
+++ b/src/components/utils/date-display.tsx
@@ -7,12 +7,14 @@ interface DateDisplayProps {
   date: Date | string
   format?: string
   className?: string
+  timezone?: string
 }
 
-export function DateDisplay({ date, format = "Pp", className }: DateDisplayProps) {
+export function DateDisplay({ date, format = "Pp", className, timezone }: DateDisplayProps) {
   const { data: session } = useSession()
+  // Use provided timezone (system), or fall back to user's timezone, or browser default
   // @ts-expect-error - types might not be generated yet
-  const userTimezone = session?.user?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+  const userTimezone = timezone || session?.user?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
   // @ts-expect-error - types might not be generated yet
   const dateFormat = session?.user?.dateFormat || "P";
   // @ts-expect-error - types might not be generated yet

--- a/src/lib/runner/steps/02-dump.ts
+++ b/src/lib/runner/steps/02-dump.ts
@@ -8,6 +8,8 @@ import { logger } from "@/lib/logger";
 import { wrapError } from "@/lib/errors";
 import { getBackupFileExtension } from "@/lib/backup-extensions";
 import { formatBytes } from "@/lib/utils";
+import prisma from "@/lib/prisma";
+import { formatInTimeZone } from "date-fns-tz";
 
 const log = logger.child({ step: "02-dump" });
 
@@ -19,15 +21,13 @@ export async function stepExecuteDump(ctx: RunnerContext) {
 
     ctx.log(`Starting Dump from ${job.source.name} (${job.source.type})...`);
 
-    // 1. Prepare Paths
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const ext = getBackupFileExtension(job.source.adapterId);
-    const fileName = `${job.name.replace(/[^a-z0-9]/gi, '_')}_${timestamp}.${ext}`;
-    const tempDir = getTempDir();
-    const tempFile = path.join(tempDir, fileName);
-
-    ctx.tempFile = tempFile;
-    ctx.log(`Prepared temporary path: ${tempFile}`);
+    // 1. Prepare Settings (timezone and filename pattern)
+    const [tzSetting, patternSetting] = await Promise.all([
+        prisma.systemSetting.findUnique({ where: { key: "system.timezone" } }),
+        prisma.systemSetting.findUnique({ where: { key: "system.filenamePattern" } }),
+    ]);
+    const timezone = tzSetting?.value || "UTC";
+    const pattern = patternSetting?.value || "{name}_yyyy-MM-dd_HH-mm-ss";
 
     // 2. Prepare Config & Metadata
     const sourceConfig = decryptConfig(JSON.parse(job.source.config));
@@ -43,6 +43,25 @@ export async function stepExecuteDump(ctx: RunnerContext) {
             return Array.isArray(parsed) ? parsed : [];
         } catch { return []; }
     })();
+
+    // 3. Generate filename with timezone and custom pattern
+    const dbNameRaw = jobDatabases.length === 0
+        ? 'all'
+        : jobDatabases.map(db => db.replace(/[^a-z0-9]/gi, '_')).join('_');
+
+    const sanitizedName = job.name.replace(/[^a-z0-9]/gi, '_');
+    const escapeName = (text: string) => text.replace(/'/g, "''");
+    let datePattern = pattern
+        .replace('{name}', `'${escapeName(sanitizedName)}'`)
+        .replace('{db_name}', `'${escapeName(dbNameRaw)}'`);
+
+    const ext = getBackupFileExtension(job.source.adapterId);
+    const fileName = formatInTimeZone(new Date(), timezone, datePattern) + `.${ext}`;
+    const tempDir = getTempDir();
+    const tempFile = path.join(tempDir, fileName);
+
+    ctx.tempFile = tempFile;
+    ctx.log(`Prepared temporary path: ${tempFile}`);
     if (jobDatabases.length > 0) {
         sourceConfig.database = jobDatabases;
         ctx.log(`Using ${jobDatabases.length} database(s) from job config: ${jobDatabases.join(', ')}`);

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -56,6 +56,11 @@ export class BackupScheduler {
         // Stop all existing tasks to avoid duplicates
         this.stopAll();
 
+        // Read system timezone once for all tasks in this refresh cycle
+        const tzSetting = await prisma.systemSetting.findUnique({ where: { key: "system.timezone" } });
+        const timezone = tzSetting?.value || "UTC";
+        log.debug("Scheduler timezone", { timezone });
+
         try {
             // 1. User Jobs
             const jobs = await prisma.job.findMany({
@@ -66,12 +71,12 @@ export class BackupScheduler {
 
             for (const job of jobs) {
                 if (cron.validate(job.schedule)) {
-                    log.debug("Scheduling job", { jobName: job.name, jobId: job.id, schedule: job.schedule });
+                    log.debug("Scheduling job", { jobName: job.name, jobId: job.id, schedule: job.schedule, timezone });
 
                     const task = cron.schedule(job.schedule, () => {
                         log.debug("Triggering job", { jobName: job.name });
                         runJob(job.id).catch((e) => log.error("Job failed", { jobId: job.id }, wrapError(e)));
-                    });
+                    }, { timezone });
 
                     this.tasks.set(job.id, task);
                 } else {
@@ -90,10 +95,10 @@ export class BackupScheduler {
 
                     const schedule = await systemTaskService.getTaskConfig(taskId);
                     if (schedule && cron.validate(schedule)) {
-                        log.debug("Scheduling system task", { taskId, schedule });
+                        log.debug("Scheduling system task", { taskId, schedule, timezone });
                         const task = cron.schedule(schedule, () => {
                             systemTaskService.runTask(taskId).catch((e) => log.error("System task failed", { taskId }, wrapError(e)));
-                        });
+                        }, { timezone });
                         this.tasks.set(taskId, task);
                     }
 

--- a/tests/unit/lib/scheduler.test.ts
+++ b/tests/unit/lib/scheduler.test.ts
@@ -12,6 +12,9 @@ vi.mock('@/lib/prisma', () => ({
         job: {
             findMany: vi.fn(),
         },
+        systemSetting: {
+            findUnique: vi.fn(),
+        },
     },
 }));
 
@@ -54,6 +57,8 @@ describe('BackupScheduler', () => {
         // @ts-expect-error -- Mock setup
         prisma.job.findMany.mockResolvedValue([]);
         // @ts-expect-error -- Mock setup
+        prisma.systemSetting.findUnique.mockResolvedValue(null);
+        // @ts-expect-error -- Mock setup
         systemTaskService.getTaskConfig.mockResolvedValue(null);
         // @ts-expect-error -- Mock setup
         systemTaskService.getTaskEnabled.mockResolvedValue(false);
@@ -83,7 +88,7 @@ describe('BackupScheduler', () => {
         expect(cron.validate).toHaveBeenCalledWith('0 0 * * *');
         expect(cron.validate).toHaveBeenCalledWith('*/5 * * * *');
         expect(cron.schedule).toHaveBeenCalledTimes(2);
-        expect(cron.schedule).toHaveBeenCalledWith('0 0 * * *', expect.any(Function));
+        expect(cron.schedule).toHaveBeenCalledWith('0 0 * * *', expect.any(Function), { timezone: 'UTC' });
 
         // Verify scheduled callback calls runJob
         // Get the callback passed to schedule for the first job
@@ -139,7 +144,7 @@ describe('BackupScheduler', () => {
 
         await scheduler.refresh();
 
-        expect(cron.schedule).toHaveBeenCalledWith('0 2 * * *', expect.any(Function));
+        expect(cron.schedule).toHaveBeenCalledWith('0 2 * * *', expect.any(Function), { timezone: 'UTC' });
 
         // Verify callback executes system task
         // @ts-expect-error -- Mock setup

--- a/tests/unit/runner/pipeline-flow.test.ts
+++ b/tests/unit/runner/pipeline-flow.test.ts
@@ -16,6 +16,9 @@ vi.mock('@/lib/prisma', () => ({
             updateMany: vi.fn(),
             findUnique: vi.fn(),
         },
+        systemSetting: {
+            findUnique: vi.fn(),
+        },
     },
 }));
 
@@ -108,6 +111,8 @@ describe('Backup Pipeline Integration', () => {
         prisma.execution.update.mockResolvedValue(mockExecution);
         // @ts-expect-error -- Mock setup -- Mock setup
         prisma.execution.create.mockResolvedValue(mockExecution);
+        // @ts-expect-error -- Mock setup
+        prisma.systemSetting.findUnique.mockResolvedValue(null);
     });
 
     afterEach(() => {


### PR DESCRIPTION
TZ is not working correctly, I added this feature in case you find it useful to integrate into the project.
Additionally, I added an output file naming format feature.

Add global timezone configuration in Settings > General > Scheduler Timezone
Scheduler now respects the timezone when executing cron jobs
Add custom pattern support for file names with tokens: {name}, {db_name}, yyyy, MM, dd, HH, mm, ss
Use formatInTimeZone from date-fns-tz to generate timestamps in the configured timezone
Add "Backup File Naming" card in settings with live preview and token chips
Examples: {name}_yyyy-MM-dd_HH-mm-ss or backup_{name}_{db_name}_yyyyMMdd
- Update runner to use timezone and pattern from SystemSettings
- Update scheduler tests and runner integration tests