### PR TITLE
feat: implement multi-database backup support with SEPARATE_FILES mode

### DIFF
--- a/prisma/migrations/20260503_add_multi_db_backup_type/migration.sql
+++ b/prisma/migrations/20260503_add_multi_db_backup_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Job" ADD COLUMN "multiDbBackupType" TEXT NOT NULL DEFAULT 'SINGLE_TAR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model Job {
   encryptionProfile   EncryptionProfile? @relation(fields: [encryptionProfileId], references: [id])
   compression         String             @default("NONE")
   pgCompression       String             @default("") // PostgreSQL native dump compression: "" (legacy gzip-6), "NONE", "GZIP:6", "LZ4:1", "ZSTD:3"
+  multiDbBackupType   String             @default("SINGLE_TAR") // "SINGLE_TAR" (all DBs in one archive) or "SEPARATE_FILES" (one file per DB)
   createdAt           DateTime           @default(now())
   updatedAt           DateTime           @updatedAt
   executions          Execution[]

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -38,7 +38,7 @@ export async function PUT(
     const params = await props.params;
     try {
         const body = await req.json();
-        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, pgCompression, notificationEvents } = body;
+        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, multiDbBackupType, pgCompression, notificationEvents } = body;
 
         const updatedJob = await jobService.updateJob(params.id, {
             name,
@@ -54,6 +54,7 @@ export async function PUT(
             notificationIds,
             encryptionProfileId,
             compression,
+            multiDbBackupType,
             pgCompression,
             notificationEvents
         });

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -34,7 +34,7 @@ export async function POST(req: NextRequest) {
         checkPermissionWithContext(ctx, PERMISSIONS.JOBS.WRITE);
 
         const body = await req.json();
-        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, pgCompression, notificationEvents } = body;
+        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, multiDbBackupType, pgCompression, notificationEvents } = body;
 
         if (!name || !schedule || !sourceId || !destinations || !Array.isArray(destinations) || destinations.length === 0) {
             return NextResponse.json({ error: "Missing required fields (name, schedule, sourceId, destinations)" }, { status: 400 });
@@ -54,6 +54,7 @@ export async function POST(req: NextRequest) {
             enabled,
             encryptionProfileId,
             compression,
+            multiDbBackupType,
             pgCompression,
             notificationEvents
         });

--- a/src/components/dashboard/jobs/job-form.tsx
+++ b/src/components/dashboard/jobs/job-form.tsx
@@ -64,6 +64,7 @@ export interface JobData {
     databases?: string;
     encryptionProfileId?: string;
     compression: string;
+    multiDbBackupType?: string;
     pgCompression?: string;
     notificationEvents?: string;
     notifications: { id: string, name: string }[];
@@ -125,6 +126,7 @@ const jobSchema = z.object({
     destinations: z.array(destinationSchema).min(1, "At least one destination is required"),
     encryptionProfileId: z.string().optional(),
     compression: z.enum(["NONE", "GZIP", "BROTLI"]).default("NONE"),
+    multiDbBackupType: z.enum(["SINGLE_TAR", "SEPARATE_FILES"]).default("SINGLE_TAR"),
     pgCompressionAlgo: z.enum(["LEGACY", "NONE", "GZIP", "LZ4", "ZSTD"]).default("LEGACY"),
     pgCompressionLevel: z.coerce.number().int().min(0).max(22).default(6),
     notificationIds: z.array(z.string()).optional(),
@@ -148,6 +150,7 @@ interface JobFormProps {
         databases?: string;
         encryptionProfileId?: string;
         compression: string;
+        multiDbBackupType?: string;
         pgCompression?: string;
         notificationEvents?: string;
         notifications: { id: string; name: string }[];
@@ -202,6 +205,7 @@ export function JobForm({ sources, destinations, notifications, encryptionProfil
             destinations: defaultDestinations,
             encryptionProfileId: initialData?.encryptionProfileId || "no-encryption",
             compression: (initialData?.compression as "NONE" | "GZIP" | "BROTLI") || "NONE",
+            multiDbBackupType: (initialData?.multiDbBackupType as "SINGLE_TAR" | "SEPARATE_FILES") || "SINGLE_TAR",
             pgCompressionAlgo: parsePgCompression(initialData?.pgCompression).algo,
             pgCompressionLevel: parsePgCompression(initialData?.pgCompression).level,
             notificationIds: initialData?.notifications?.map((n) => n.id) || [],
@@ -231,8 +235,12 @@ export function JobForm({ sources, destinations, notifications, encryptionProfil
     const isPgSource = selectedSource?.adapterId === "postgres";
     const pgMajorVersion = isPgSource ? parsePgMajorVersion(selectedSource?.metadata) : null;
 
+    // Watch databases to show/hide multiDbBackupType option
+    const selectedDatabases = form.watch("databases") || [];
+    const showMultiDbOptions = selectedDatabases.length > 1;
+
     const pgCompressionAlgo = (form.watch("pgCompressionAlgo") ?? "LEGACY") as PgCompressionAlgo;
-    const isNativeCompressionActive = ["LEGACY", "GZIP", "LZ4", "ZSTD"].includes(pgCompressionAlgo);
+    const isNativeCompressionActive = isPgSource && ["LEGACY", "GZIP", "LZ4", "ZSTD"].includes(pgCompressionAlgo);
 
     // Auto-disable external compression when native pg compression is active
     useEffect(() => {
@@ -692,6 +700,29 @@ export function JobForm({ sources, destinations, notifications, encryptionProfil
                                     )}
                                 </div>
                             </div>
+                        )}
+
+                        {showMultiDbOptions && (
+                            <FormField control={form.control} name="multiDbBackupType" render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Multi-Database Backup Type</FormLabel>
+                                    <Select onValueChange={field.onChange} value={field.value}>
+                                        <FormControl>
+                                            <SelectTrigger>
+                                                <SelectValue placeholder="Select backup type" />
+                                            </SelectTrigger>
+                                        </FormControl>
+                                        <SelectContent>
+                                            <SelectItem value="SINGLE_TAR">Single TAR Archive (All DBs)</SelectItem>
+                                            <SelectItem value="SEPARATE_FILES">Separate Files (One per DB)</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <FormDescription>
+                                        Choose how to group databases when multiple are selected. Single TAR groups all databases into one archive. Separate Files creates individual backup files for each database.
+                                    </FormDescription>
+                                    <FormMessage />
+                                </FormItem>
+                            )} />
                         )}
                     </TabsContent>
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -43,15 +43,18 @@ function CommandDialog({
   className?: string
   showCloseButton?: boolean
 }) {
+  const descriptionId = React.useId()
+
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
         <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
+        <DialogDescription id={descriptionId}>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
+        aria-describedby={descriptionId}
       >
         <Command className="**:[[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}

--- a/src/lib/adapters/database/common/tar-utils.ts
+++ b/src/lib/adapters/database/common/tar-utils.ts
@@ -23,6 +23,50 @@ import {
 export const MANIFEST_FILENAME = "manifest.json";
 
 /**
+ * Helper to add a manifest to an existing tar stream.
+ * Useful for adapters like MSSQL that create their own TAR streams.
+ * @param tarPack - Active tar-stream pack instance
+ * @param databases - Database names in the archive
+ * @param sourceType - Type of database engine
+ * @param backupType - SINGLE_TAR or SEPARATE_FILES
+ * @param engineVersion - Optional engine version
+ */
+export async function addManifestToTar(
+    tarPack: any,
+    databases: string[],
+    sourceType: string,
+    backupType: "SINGLE_TAR" | "SEPARATE_FILES" = "SINGLE_TAR",
+    engineVersion?: string
+): Promise<TarManifest> {
+    const manifest: TarManifest = {
+        version: 1,
+        createdAt: new Date().toISOString(),
+        sourceType,
+        engineVersion,
+        backupType,
+        databases: databases.map(name => ({
+            name,
+            filename: `${name}.bak`,
+            size: 0, // Size will be calculated during packing
+            format: "bak" as const,
+        })),
+        totalSize: 0,
+    };
+
+    // Add manifest.json as first entry
+    const manifestJson = JSON.stringify(manifest, null, 2);
+    const manifestBuffer = Buffer.from(manifestJson, "utf-8");
+
+    const manifestEntry = tarPack.entry({
+        name: MANIFEST_FILENAME,
+        size: manifestBuffer.length,
+    });
+    manifestEntry.end(manifestBuffer);
+
+    return manifest;
+}
+
+/**
  * Create a TAR archive containing multiple database dumps
  *
  * @param files - Array of files to include in the archive
@@ -62,6 +106,7 @@ export async function createMultiDbTar(
         createdAt: new Date().toISOString(),
         sourceType: options.sourceType,
         engineVersion: options.engineVersion,
+        backupType: options.backupType || "SINGLE_TAR",
         databases,
         totalSize,
     };

--- a/src/lib/adapters/database/common/types.ts
+++ b/src/lib/adapters/database/common/types.ts
@@ -32,6 +32,8 @@ export interface TarManifest {
     sourceType: string;
     /** Database engine version (e.g., "8.0.32", "15.2") */
     engineVersion?: string;
+    /** Backup type: SINGLE_TAR (all DBs in one stream) or SEPARATE_FILES (individual files per DB) */
+    backupType?: "SINGLE_TAR" | "SEPARATE_FILES";
     /** List of databases in the archive */
     databases: DatabaseEntry[];
     /** Total size of all dumps in bytes (uncompressed) */
@@ -56,6 +58,8 @@ export interface CreateTarOptions {
     sourceType: string;
     /** Database engine version */
     engineVersion?: string;
+    /** Backup type: SINGLE_TAR or SEPARATE_FILES */
+    backupType?: "SINGLE_TAR" | "SEPARATE_FILES";
 }
 
 /**

--- a/src/lib/adapters/database/mongodb/dump.ts
+++ b/src/lib/adapters/database/mongodb/dump.ts
@@ -207,39 +207,85 @@ export async function dump(
             log(`Starting single-database dump (archive format)`, 'info');
             await dumpSingleDatabase(dbs[0] || '', destinationPath, config, log);
         }
-        // Case 2: Multiple Databases - TAR archive with individual mongodump per DB
+        // Case 2: Multiple Databases - TAR archive or separate files
         else {
-            log(`Dumping ${dbs.length} databases using TAR archive: ${dbs.join(', ')}`, 'info');
+            const backupType = (config as any).multiDbBackupType || 'SINGLE_TAR';
 
-            tempDir = await createTempDir('mongo-multidb-');
-            log(`Created temp directory: ${tempDir}`, 'info');
+            if (backupType === 'SEPARATE_FILES') {
+                log(`Dumping ${dbs.length} databases as separate files: ${dbs.join(', ')}`, 'info');
 
-            const tarFiles: TarFileEntry[] = [];
+                tempDir = await createTempDir('mongo-multidb-');
+                log(`Created temp directory: ${tempDir}`, 'info');
 
-            for (const dbName of dbs) {
-                const dumpFilename = `${dbName}.archive`;
-                const dumpPath = path.join(tempDir, dumpFilename);
+                const finalFiles = [];
 
-                await dumpSingleDatabase(dbName, dumpPath, config, log);
-                log(`Database ${dbName} dumped successfully`, 'success');
+                for (const dbName of dbs) {
+                    const dumpFilename = `${dbName}.archive`;
+                    const dumpPath = path.join(tempDir, dumpFilename);
 
-                tarFiles.push({
-                    name: dumpFilename,
-                    path: dumpPath,
-                    dbName,
-                    format: 'archive',
+                    await dumpSingleDatabase(dbName, dumpPath, config, log);
+                    log(`Database ${dbName} dumped successfully`, 'success');
+
+                    const finalPath = path.join(path.dirname(destinationPath), dumpFilename);
+                    await fs.copyFile(dumpPath, finalPath);
+                    const fileStats = await fs.stat(finalPath);
+                    finalFiles.push({
+                        path: finalPath,
+                        name: dumpFilename,
+                        size: fileStats.size,
+                        database: dbName,
+                    });
+                    log(`Prepared file: ${dumpFilename}`, 'success');
+                }
+
+                log(`SEPARATE_FILES backup ready: ${finalFiles.length} files`, 'success');
+                await cleanupTempDir(tempDir);
+                tempDir = null;
+
+                return {
+                    success: true,
+                    files: finalFiles,
+                    logs,
+                    startedAt,
+                    completedAt: new Date(),
+                    metadata: {
+                        databases: dbs,
+                    },
+                };
+            } else {
+                log(`Dumping ${dbs.length} databases using TAR archive: ${dbs.join(', ')}`, 'info');
+
+                tempDir = await createTempDir('mongo-multidb-');
+                log(`Created temp directory: ${tempDir}`, 'info');
+
+                const tarFiles: TarFileEntry[] = [];
+
+                for (const dbName of dbs) {
+                    const dumpFilename = `${dbName}.archive`;
+                    const dumpPath = path.join(tempDir, dumpFilename);
+
+                    await dumpSingleDatabase(dbName, dumpPath, config, log);
+                    log(`Database ${dbName} dumped successfully`, 'success');
+
+                    tarFiles.push({
+                        name: dumpFilename,
+                        path: dumpPath,
+                        dbName,
+                        format: 'archive',
+                    });
+                }
+
+                // Create TAR archive with manifest
+                log(`Creating TAR archive with ${tarFiles.length} databases...`, 'info');
+                const manifest: TarManifest = await createMultiDbTar(tarFiles, destinationPath, {
+                    sourceType: 'mongodb',
+                    engineVersion: config.detectedVersion || 'unknown',
+                    backupType: 'SINGLE_TAR',
                 });
+
+                log(`Multi-database TAR archive created successfully`, 'success');
+                log(`Manifest: ${manifest.databases.length} databases, ${manifest.totalSize} bytes`, 'info');
             }
-
-            // Create TAR archive with manifest
-            log(`Creating TAR archive with ${tarFiles.length} databases...`, 'info');
-            const manifest: TarManifest = await createMultiDbTar(tarFiles, destinationPath, {
-                sourceType: 'mongodb',
-                engineVersion: config.detectedVersion || 'unknown',
-            });
-
-            log(`Multi-database TAR archive created successfully`, 'success');
-            log(`Manifest: ${manifest.databases.length} databases, ${manifest.totalSize} bytes`, 'info');
         }
 
         // Verify
@@ -248,7 +294,7 @@ export async function dump(
             throw new Error("Dump file is empty. Check logs/permissions.");
         }
 
-        return {
+        const result: any = {
             success: true,
             path: destinationPath,
             size: stats.size,
@@ -256,6 +302,15 @@ export async function dump(
             startedAt,
             completedAt: new Date(),
         };
+
+        // Add metadata for multi-database backups
+        if (dbs.length > 1) {
+            result.metadata = {
+                databases: dbs,
+            };
+        }
+
+        return result;
 
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/lib/adapters/database/mssql/dump.ts
+++ b/src/lib/adapters/database/mssql/dump.ts
@@ -162,10 +162,45 @@ export async function dump(
             }
 
             // Copy backup file(s) to final destination
+            const backupType = (config as any).multiDbBackupType || 'SINGLE_TAR';
+
             if (tempFiles.length === 1) {
                 // Single database - copy directly
                 await copyFile(tempFiles[0].local, destinationPath);
                 log(`Backup file copied to: ${destinationPath}`);
+            } else if (backupType === 'SEPARATE_FILES') {
+                // Multiple databases - copy each .bak file separately
+                log(`Preparing ${tempFiles.length} separate backup files...`);
+
+                const finalFiles = [];
+                for (let i = 0; i < tempFiles.length; i++) {
+                    const f = tempFiles[i];
+                    const dbName = databases[i];
+                    const finalPath = path.join(path.dirname(destinationPath), `${dbName}.bak`);
+                    await copyFile(f.local, finalPath);
+                    const fileStats = await fs.stat(finalPath);
+                    finalFiles.push({
+                        path: finalPath,
+                        name: `${dbName}.bak`,
+                        size: fileStats.size,
+                        database: dbName,
+                    });
+                    log(`Prepared file: ${dbName}.bak`, 'success');
+                }
+
+                log(`SEPARATE_FILES backup ready: ${finalFiles.length} files`, 'success');
+                const result: any = {
+                    success: true,
+                    files: finalFiles,
+                    logs,
+                    startedAt,
+                    completedAt: new Date(),
+                    metadata: {
+                        databases,
+                    },
+                };
+                await cleanupTempFiles();
+                return result;
             } else {
                 // Multiple databases - pack all .bak files into a tar archive
                 // MSSQL cannot create multi-DB backups in a single file like MySQL
@@ -219,7 +254,7 @@ export async function dump(
             const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
             log(`Backup finished successfully. Size: ${sizeMB} MB`);
 
-            return {
+            const result: any = {
                 success: true,
                 path: destinationPath,
                 size: stats.size,
@@ -227,6 +262,19 @@ export async function dump(
                 startedAt,
                 completedAt: new Date(),
             };
+
+            // Add metadata for multi-database backups
+            if (databases.length > 1) {
+                result.metadata = {
+                    multiDb: {
+                        format: "tar",
+                        databases,
+                        backupType: (config as any).multiDbBackupType || "SINGLE_TAR",
+                    },
+                };
+            }
+
+            return result;
         } finally {
             // Always clean up temp .bak files (even on error/abort)
             await cleanupTempFiles();

--- a/src/lib/adapters/database/mysql/dump.ts
+++ b/src/lib/adapters/database/mysql/dump.ts
@@ -193,11 +193,13 @@ export async function dump(config: MySQLDumpConfig, destinationPath: string, onL
             };
         }
 
-        // Multi-DB: Dump each database separately, then pack into TAR
-        log(`Multi-database backup: ${dbs.length} databases`);
+        // Multi-DB: Dump each database separately, then either pack into TAR or keep separate
+        const backupType = (config as any).multiDbBackupType || 'SINGLE_TAR';
+        log(`Multi-database backup: ${dbs.length} databases (${backupType})`);
 
         const tempDir = await createTempDir("mysql-multidb-");
         const dbFiles: TarFileEntry[] = [];
+        const dumpedFiles: Array<{ path: string; name: string; size: number; database: string }> = [];
 
         try {
             for (const dbName of dbs) {
@@ -206,41 +208,82 @@ export async function dump(config: MySQLDumpConfig, destinationPath: string, onL
 
                 await dumpSingleDatabase(config, dbName, dbFilePath, log);
 
-                dbFiles.push({
-                    name: dbFileName,
+                const stats = await fs.stat(dbFilePath);
+                dumpedFiles.push({
                     path: dbFilePath,
-                    dbName,
-                    format: "sql",
+                    name: dbFileName,
+                    size: stats.size,
+                    database: dbName,
                 });
+
+                if (backupType === 'SINGLE_TAR') {
+                    dbFiles.push({
+                        name: dbFileName,
+                        path: dbFilePath,
+                        dbName,
+                        format: "sql",
+                    });
+                }
 
                 log(`Completed dump for: ${dbName}`);
             }
 
-            // Create TAR archive with manifest
-            log(`Creating TAR archive with ${dbFiles.length} databases...`);
-            const manifest = await createMultiDbTar(dbFiles, destinationPath, {
-                sourceType: config.type === 'mariadb' ? 'mariadb' : 'mysql',
-                engineVersion: config.detectedVersion,
-            });
+            // Handle based on backup type
+            if (backupType === 'SEPARATE_FILES') {
+                log(`Preparing ${dumpedFiles.length} separate backup files...`);
 
-            const stats = await fs.stat(destinationPath);
-            const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
-            log(`Multi-DB backup finished successfully. Size: ${sizeMB} MB`);
+                const finalFiles = [];
+                for (const file of dumpedFiles) {
+                    const finalPath = path.join(path.dirname(destinationPath), `${file.database}.sql`);
+                    await fs.copyFile(file.path, finalPath);
+                    finalFiles.push({
+                        path: finalPath,
+                        name: `${file.database}.sql`,
+                        size: file.size,
+                        database: file.database,
+                    });
+                    log(`Prepared file: ${file.database}.sql`, 'success');
+                }
 
-            return {
-                success: true,
-                path: destinationPath,
-                size: stats.size,
-                logs,
-                startedAt,
-                completedAt: new Date(),
-                metadata: {
-                    multiDb: {
-                        format: 'tar',
-                        databases: manifest.databases.map(d => d.name),
+                log(`SEPARATE_FILES backup ready: ${finalFiles.length} files`, 'success');
+                return {
+                    success: true,
+                    files: finalFiles,
+                    logs,
+                    startedAt,
+                    completedAt: new Date(),
+                    metadata: {
+                        databases: dbs,
                     },
-                },
-            };
+                };
+            } else {
+                // Create TAR archive with manifest
+                log(`Creating TAR archive with ${dbFiles.length} databases...`);
+                const manifest = await createMultiDbTar(dbFiles, destinationPath, {
+                    sourceType: config.type === 'mariadb' ? 'mariadb' : 'mysql',
+                    engineVersion: config.detectedVersion,
+                    backupType: 'SINGLE_TAR',
+                });
+
+                const stats = await fs.stat(destinationPath);
+                const sizeMB = (stats.size / 1024 / 1024).toFixed(2);
+                log(`Multi-DB backup finished successfully. Size: ${sizeMB} MB`);
+
+                return {
+                    success: true,
+                    path: destinationPath,
+                    size: stats.size,
+                    logs,
+                    startedAt,
+                    completedAt: new Date(),
+                    metadata: {
+                        multiDb: {
+                            format: 'tar',
+                            databases: manifest.databases.map(d => d.name),
+                        },
+                    },
+                };
+            }
         } finally {
             // Always cleanup temp files
             await cleanupTempDir(tempDir);

--- a/src/lib/adapters/database/postgres/dump.ts
+++ b/src/lib/adapters/database/postgres/dump.ts
@@ -249,14 +249,16 @@ export async function dump(
             log(`Starting single-database dump (custom format)`, 'info');
             await dumpSingleDatabase(dbs[0], destinationPath, config, env, log);
         }
-        // Case 2: Multiple Databases - TAR archive with individual pg_dump per DB
+        // Case 2: Multiple Databases - Either separate files or TAR archive
         else {
-            log(`Dumping ${dbs.length} databases using TAR archive: ${dbs.join(', ')}`, 'info');
+            const backupType = (config as any).multiDbBackupType || 'SINGLE_TAR';
+            log(`Dumping ${dbs.length} databases (${backupType}): ${dbs.join(', ')}`, 'info');
 
             // Create temp directory for individual dumps
             tempDir = await createTempDir('pg-multidb-');
             log(`Created temp directory: ${tempDir}`, 'info');
 
+            const dumpedFiles: Array<{ path: string; name: string; size: number; database: string }> = [];
             const tarFiles: TarFileEntry[] = [];
 
             // Dump each database individually with custom format
@@ -267,23 +269,65 @@ export async function dump(
                 await dumpSingleDatabase(dbName, dumpPath, config, env, log);
                 log(`Database ${dbName} dumped successfully`, 'success');
 
-                tarFiles.push({
-                    name: dumpFilename,
+                const stats = await fs.stat(dumpPath);
+                dumpedFiles.push({
                     path: dumpPath,
-                    dbName,
-                    format: 'custom', // PostgreSQL custom format
+                    name: dumpFilename,
+                    size: stats.size,
+                    database: dbName,
                 });
+
+                if (backupType === 'SINGLE_TAR') {
+                    tarFiles.push({
+                        name: dumpFilename,
+                        path: dumpPath,
+                        dbName,
+                        format: 'custom',
+                    });
+                }
             }
 
-            // Create TAR archive with manifest
-            log(`Creating TAR archive with ${tarFiles.length} databases...`, 'info');
-            const manifest: TarManifest = await createMultiDbTar(tarFiles, destinationPath, {
-                sourceType: 'postgres',
-                engineVersion: config.detectedVersion || 'unknown',
-            });
+            // Handle based on backup type
+            if (backupType === 'SEPARATE_FILES') {
+                // Copy each file to final destination with database name prefix
+                log(`Preparing ${dumpedFiles.length} separate backup files...`, 'info');
 
-            log(`Multi-database TAR archive created successfully`, 'success');
-            log(`Manifest: ${manifest.databases.length} databases, ${manifest.totalSize} bytes`, 'info');
+                const finalFiles = [];
+                for (const file of dumpedFiles) {
+                    const finalPath = path.join(path.dirname(destinationPath), `${file.database}.dump`);
+                    await fs.copyFile(file.path, finalPath);
+                    finalFiles.push({
+                        path: finalPath,
+                        name: `${file.database}.dump`,
+                        size: file.size,
+                        database: file.database,
+                    });
+                    log(`Prepared file: ${file.database}.dump`, 'success');
+                }
+
+                log(`SEPARATE_FILES backup ready: ${finalFiles.length} files`, 'success');
+                return {
+                    success: true,
+                    files: finalFiles,
+                    logs,
+                    startedAt,
+                    completedAt: new Date(),
+                    metadata: {
+                        databases: dbs,
+                    },
+                };
+            } else {
+                // Create TAR archive with manifest
+                log(`Creating TAR archive with ${tarFiles.length} databases...`, 'info');
+                const manifest: TarManifest = await createMultiDbTar(tarFiles, destinationPath, {
+                    sourceType: 'postgres',
+                    engineVersion: config.detectedVersion || 'unknown',
+                    backupType: 'SINGLE_TAR',
+                });
+
+                log(`Multi-database TAR archive created successfully`, 'success');
+                log(`Manifest: ${manifest.databases.length} databases, ${manifest.totalSize} bytes`, 'info');
+            }
         }
 
         const stats = await fs.stat(destinationPath);

--- a/src/lib/backup-extensions.ts
+++ b/src/lib/backup-extensions.ts
@@ -14,10 +14,14 @@
  */
 export function getBackupFileExtension(adapterId: string): string {
     const extensions: Record<string, string> = {
-        // SQL-based databases use .sql
+        // SQL text-based databases
         mysql: "sql",
         mariadb: "sql",
-        postgres: "sql",
+
+        // PostgreSQL uses custom binary format (more efficient than SQL text)
+        postgres: "dump",
+
+        // SQL Server native backup format
         mssql: "bak",
 
         // NoSQL and special formats

--- a/src/lib/core/interfaces.ts
+++ b/src/lib/core/interfaces.ts
@@ -37,10 +37,10 @@ export interface BackupMetadata {
         iv: string;
         authTag: string;
     };
-    /** Multi-DB TAR archive metadata */
+    /** Multi-DB archive metadata (TAR or separate files) */
     multiDb?: {
-        format: 'tar';
-        /** Database names contained in the archive */
+        format: 'tar' | 'separate_files';
+        /** Database names contained in the archive or files */
         databases: string[];
     };
     /** SHA-256 checksum of the final backup file (after compression/encryption) */
@@ -84,8 +84,10 @@ export interface BaseAdapter {
 
 export type BackupResult = {
     success: boolean;
-    path?: string;
-    size?: number;
+    path?: string; // Single file (for SINGLE_TAR or single DB)
+    size?: number; // Single file size
+    /** Multiple files for SEPARATE_FILES backups */
+    files?: Array<{ path: string; name: string; size: number; database: string }>;
     error?: string;
     logs: string[];
     /** Partial metadata from adapter - will be merged with full metadata in runner */

--- a/src/lib/runner/steps/02-dump.ts
+++ b/src/lib/runner/steps/02-dump.ts
@@ -34,6 +34,9 @@ export async function stepExecuteDump(ctx: RunnerContext) {
     // Inject adapterId as type for Dialect selection (e.g. 'mariadb')
     sourceConfig.type = job.source.adapterId;
 
+    // Inject multiDbBackupType for handling multiple databases
+    sourceConfig.multiDbBackupType = job.multiDbBackupType || 'SINGLE_TAR';
+
     // Inject databases from Job (always takes precedence over source config).
     // An empty job selection means "backup all" - clear the source's default database
     // so each adapter's auto-discovery logic triggers instead of using the source default.
@@ -237,13 +240,58 @@ export async function stepExecuteDump(ctx: RunnerContext) {
         throw new Error(`Dump failed: ${dumpResult.error}`);
     }
 
-    // If adapter appended an extension (like .gz), use that path
-    if (dumpResult.path && dumpResult.path !== tempFile) {
-        ctx.tempFile = dumpResult.path;
-    }
+    // Handle both single file and multiple files (SEPARATE_FILES mode)
+    if (dumpResult.files && dumpResult.files.length > 0) {
+        // SEPARATE_FILES mode: multiple files
+        // Apply the filename pattern to each database file
+        const renamedFiles = [];
 
-    ctx.dumpSize = dumpResult.size || 0;
-    ctx.log(`Dump successful. Size: ${dumpResult.size} bytes`);
+        for (const dumpFile of dumpResult.files) {
+            // Generate filename for this specific database using the pattern
+            const dbSpecificDbName = dumpFile.database.replace(/[^a-z0-9]/gi, '_');
+            const escapeName = (text: string) => text.replace(/'/g, "''");
+            let dbSpecificPattern = pattern
+                .replace('{name}', `'${escapeName(sanitizedName)}'`)
+                .replace('{db_name}', `'${escapeName(dbSpecificDbName)}'`);
+
+            const dbSpecificFileName = formatInTimeZone(new Date(), timezone, dbSpecificPattern) + `.${ext}`;
+            const dbSpecificPath = path.join(path.dirname(dumpFile.path), dbSpecificFileName);
+
+            // Rename the file to the new name
+            if (dumpFile.path !== dbSpecificPath) {
+                await fs.rename(dumpFile.path, dbSpecificPath);
+                ctx.log(`Renamed ${dumpFile.database} backup to: ${dbSpecificFileName}`);
+            }
+
+            renamedFiles.push({
+                path: dbSpecificPath,
+                name: dbSpecificFileName,
+                database: dumpFile.database,
+                size: dumpFile.size
+            });
+        }
+
+        ctx.dumpFiles = renamedFiles;
+        ctx.dumpSize = renamedFiles.reduce((sum, f) => sum + f.size, 0);
+        ctx.log(`Dump successful (${renamedFiles.length} separate files). Total size: ${ctx.dumpSize} bytes`);
+        // Create a manifest file for reference
+        const manifestPath = path.join(getTempDir(), `${path.basename(tempFile)}.manifest.json`);
+        await fs.writeFile(manifestPath, JSON.stringify({
+            format: 'separate_files',
+            files: renamedFiles.map(f => ({ name: f.name, database: f.database, size: f.size }))
+        }, null, 2));
+    } else if (dumpResult.path) {
+        // Single file mode
+        if (dumpResult.path !== tempFile) {
+            ctx.tempFile = dumpResult.path;
+        } else {
+            ctx.tempFile = tempFile;
+        }
+        ctx.dumpSize = dumpResult.size || 0;
+        ctx.log(`Dump successful. Size: ${dumpResult.size} bytes`);
+    } else {
+        throw new Error("Dump result has neither path nor files");
+    }
 
     // If metadata has no DB names yet (auto-discovered during dump), fetch them now
     if (ctx.metadata && (!ctx.metadata.names || ctx.metadata.names.length === 0)) {
@@ -268,32 +316,45 @@ export async function stepExecuteDump(ctx: RunnerContext) {
         }
     }
 
-    // Check if the dump is a Multi-DB TAR archive and update metadata
-    try {
-        const dumpPath = ctx.tempFile;
-        if (await isMultiDbTar(dumpPath)) {
-            const manifest = await readTarManifest(dumpPath);
-            if (manifest) {
-                ctx.metadata = {
-                    ...ctx.metadata,
-                    multiDb: {
-                        format: 'tar',
-                        databases: manifest.databases.map(db => db.name)
-                    }
-                };
-                ctx.log(`Multi-DB TAR archive detected: ${manifest.databases.length} databases`);
+    // Check if we have separate files (SEPARATE_FILES mode) or a Multi-DB TAR archive
+    if (ctx.dumpFiles && ctx.dumpFiles.length > 0) {
+        // SEPARATE_FILES mode
+        ctx.metadata = {
+            ...ctx.metadata,
+            multiDb: {
+                format: 'separate_files',
+                databases: ctx.dumpFiles.map(f => f.database)
+            }
+        };
+        ctx.log(`Separate files mode detected: ${ctx.dumpFiles.length} databases`);
+    } else if (ctx.tempFile) {
+        // Check if it's a Multi-DB TAR archive
+        try {
+            const dumpPath = ctx.tempFile;
+            if (await isMultiDbTar(dumpPath)) {
+                const manifest = await readTarManifest(dumpPath);
+                if (manifest) {
+                    ctx.metadata = {
+                        ...ctx.metadata,
+                        multiDb: {
+                            format: 'tar',
+                            databases: manifest.databases.map(db => db.name)
+                        }
+                    };
+                    ctx.log(`Multi-DB TAR archive detected: ${manifest.databases.length} databases`);
 
-                // Rename file to .tar extension to reflect actual format
-                if (!dumpPath.endsWith('.tar')) {
-                    const tarPath = dumpPath.replace(/\.[^.]+$/, '.tar');
-                    await fs.rename(dumpPath, tarPath);
-                    ctx.tempFile = tarPath;
-                    ctx.log(`Renamed backup file to .tar extension: ${path.basename(tarPath)}`);
+                    // Rename file to .tar extension to reflect actual format
+                    if (!dumpPath.endsWith('.tar')) {
+                        const tarPath = dumpPath.replace(/\.[^.]+$/, '.tar');
+                        await fs.rename(dumpPath, tarPath);
+                        ctx.tempFile = tarPath;
+                        ctx.log(`Renamed backup file to .tar extension: ${path.basename(tarPath)}`);
+                    }
                 }
             }
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            ctx.log(`Warning: Could not check for Multi-DB TAR format: ${message}`);
         }
-    } catch (e: unknown) {
-        const message = e instanceof Error ? e.message : String(e);
-        ctx.log(`Warning: Could not check for Multi-DB TAR format: ${message}`);
     }
 }

--- a/src/lib/runner/steps/03-upload.ts
+++ b/src/lib/runner/steps/03-upload.ts
@@ -14,10 +14,13 @@ import { getTempDir } from "@/lib/temp-dir";
 import { PIPELINE_STAGES } from "@/lib/core/logs";
 
 export async function stepUpload(ctx: RunnerContext) {
-    if (!ctx.job || ctx.destinations.length === 0 || !ctx.tempFile) throw new Error("Context not ready for upload");
+    if (!ctx.job || ctx.destinations.length === 0 || (!ctx.tempFile && (!ctx.dumpFiles || ctx.dumpFiles.length === 0))) {
+        throw new Error("Context not ready for upload");
+    }
 
     const job = ctx.job;
     const compression = (job as any).compression as CompressionType;
+    const isSeparateFiles = ctx.dumpFiles && ctx.dumpFiles.length > 0;
 
     // Determine Action Label for UI
     const actions: string[] = [];
@@ -25,17 +28,29 @@ export async function stepUpload(ctx: RunnerContext) {
     if (job.encryptionProfileId) actions.push("Encrypting");
     const processingLabel = actions.length > 0 ? actions.join(" & ") : "Processing";
 
-    if (actions.length > 0) {
-        ctx.setStage(PIPELINE_STAGES.PROCESSING);
+    // For SEPARATE_FILES mode, skip compression/encryption at the pipeline level
+    // Each file will be handled individually
+    if (!isSeparateFiles) {
+        if (actions.length > 0) {
+            ctx.setStage(PIPELINE_STAGES.PROCESSING);
+        } else {
+            ctx.setStage(PIPELINE_STAGES.UPLOADING);
+        }
     } else {
         ctx.setStage(PIPELINE_STAGES.UPLOADING);
     }
 
+    // --- HANDLE SEPARATE FILES MODE ---
+    if (isSeparateFiles) {
+        // SEPARATE_FILES: skip pipeline, upload files directly
+        return uploadSeparateFiles(ctx, job, compression);
+    }
+
     // --- PIPELINE CONSTRUCTION (once, shared across all destinations) ---
-    let currentFile = ctx.tempFile;
+    let currentFile = ctx.tempFile!;
     const transformStreams: any[] = [];
 
-    const sourceStat = await fs.stat(ctx.tempFile);
+    const sourceStat = await fs.stat(ctx.tempFile!);
     const sourceSize = sourceStat.size;
     const progressMonitor = new ProgressMonitorStream(sourceSize, (processed, total, percent, speed) => {
         ctx.updateDetail(`${processingLabel} (${formatBytes(processed)} / ${formatBytes(total)}) – ${formatBytes(speed)}/s`);
@@ -90,7 +105,7 @@ export async function stepUpload(ctx: RunnerContext) {
         transformStreams.unshift(progressMonitor);
 
         try {
-            const inputFile = ctx.tempFile;
+            const inputFile = ctx.tempFile!;
 
             await pipeline([
                 createReadStream(inputFile),
@@ -117,7 +132,7 @@ export async function stepUpload(ctx: RunnerContext) {
 
     // --- CHECKSUM CALCULATION ---
     ctx.log("Calculating SHA-256 checksum...");
-    const checksum = await calculateFileChecksum(ctx.tempFile);
+    const checksum = await calculateFileChecksum(ctx.tempFile!);
     ctx.log(`Checksum: ${checksum}`);
 
     // --- METADATA SIDECAR (created once, uploaded to each destination) ---
@@ -135,18 +150,18 @@ export async function stepUpload(ctx: RunnerContext) {
         engineVersion: ctx.metadata?.engineVersion,
         engineEdition: ctx.metadata?.engineEdition,
         timestamp: new Date().toISOString(),
-        originalFileName: path.basename(ctx.tempFile),
+        originalFileName: path.basename(ctx.tempFile!),
         compression: compressionMeta,
         encryption: encryptionMeta,
         checksum,
         multiDb: ctx.metadata?.multiDb
     };
 
-    const metaPath = ctx.tempFile + ".meta.json";
+    const metaPath = ctx.tempFile! + ".meta.json";
     await fs.writeFile(metaPath, JSON.stringify(metadata, null, 2));
 
     // --- SEQUENTIAL UPLOAD TO ALL DESTINATIONS ---
-    const remotePath = `${job.name}/${path.basename(ctx.tempFile)}`;
+    const remotePath = `${job.name}/${path.basename(ctx.tempFile!)}`;
     const totalDests = ctx.destinations.length;
 
     ctx.setStage(PIPELINE_STAGES.UPLOADING);
@@ -190,7 +205,7 @@ export async function stepUpload(ctx: RunnerContext) {
             // Upload main backup file
             const uploadSuccess = await dest.adapter.upload(
                 dest.config,
-                ctx.tempFile,
+                ctx.tempFile!,
                 remotePath,
                 destProgress,
                 (msg, level, type, details) => ctx.log(`${destLabel} ${msg}`, level, type, details)
@@ -225,7 +240,7 @@ export async function stepUpload(ctx: RunnerContext) {
         for (const { dest, destLabel } of verifyQueue) {
             try {
                 ctx.log(`${destLabel} Verifying upload integrity...`);
-                const verifyPath = path.join(getTempDir(), `verify_${Date.now()}_${path.basename(ctx.tempFile)}`);
+                const verifyPath = path.join(getTempDir(), `verify_${Date.now()}_${path.basename(ctx.tempFile!)}`);
                 const downloadOk = await dest.adapter.download(dest.config, remotePath, verifyPath);
                 if (downloadOk) {
                     const result = await verifyFileChecksum(verifyPath, checksum);
@@ -264,5 +279,242 @@ export async function stepUpload(ctx: RunnerContext) {
         ctx.log(`Upload summary: ${successCount}/${totalDests} successful, ${failCount} failed`, 'warning');
     } else {
         ctx.log(`Upload summary: All ${successCount} destination(s) successful`);
+    }
+}
+
+/**
+ * Upload separate database files individually
+ */
+async function uploadSeparateFiles(ctx: RunnerContext, job: any, compression: CompressionType) {
+    if (!ctx.dumpFiles || ctx.dumpFiles.length === 0) {
+        throw new Error("No dump files found for SEPARATE_FILES upload");
+    }
+
+    const totalDests = ctx.destinations.length;
+    const totalFiles = ctx.dumpFiles.length;
+    let uploadedSuccessfully = 0;
+
+    ctx.log("Processing separate database files for compression and checksums...");
+
+    // Process each file: compress (if configured) and calculate checksums
+    const processedFiles: Array<{
+        originalPath: string;
+        finalPath: string;
+        originalName: string;
+        finalName: string;
+        database: string;
+        size: number;
+        compression?: CompressionType;
+        checksum?: string;
+    }> = [];
+
+    for (let i = 0; i < totalFiles; i++) {
+        const dumpFile = ctx.dumpFiles[i];
+        let currentPath = dumpFile.path;
+        let currentName = dumpFile.name;
+        let currentSize = dumpFile.size;
+        let appliedCompression: CompressionType | undefined;
+
+        // Apply compression to each file if configured
+        if (compression && compression !== 'NONE') {
+            ctx.log(`Compressing ${dumpFile.database}: ${compression}...`);
+            const compStream = getCompressionStream(compression);
+            if (compStream) {
+                const ext = getCompressionExtension(compression);
+                const compressedPath = currentPath + ext;
+                const compressedName = currentName + ext;
+
+                await pipeline([
+                    createReadStream(currentPath),
+                    compStream,
+                    createWriteStream(compressedPath)
+                ]);
+
+                await fs.unlink(currentPath).catch(() => {});
+                currentPath = compressedPath;
+                currentName = compressedName;
+                const compStat = await fs.stat(compressedPath);
+                currentSize = compStat.size;
+                appliedCompression = compression;
+                ctx.log(`Compressed ${dumpFile.database}: ${formatBytes(dumpFile.size)} → ${formatBytes(currentSize)}`);
+            }
+        }
+
+        // Calculate checksum for the final file
+        ctx.log(`Calculating checksum for ${dumpFile.database}...`);
+        const checksum = await calculateFileChecksum(currentPath);
+        ctx.log(`Checksum for ${dumpFile.database}: ${checksum}`);
+
+        processedFiles.push({
+            originalPath: dumpFile.path,
+            finalPath: currentPath,
+            originalName: dumpFile.name,
+            finalName: currentName,
+            database: dumpFile.database,
+            size: currentSize,
+            compression: appliedCompression,
+            checksum
+        });
+    }
+
+    // Create manifest file with compression and checksum info
+    const manifest: BackupMetadata = {
+        version: 1,
+        jobId: job.id,
+        jobName: job.name,
+        sourceName: job.source.name,
+        sourceType: job.source.adapterId,
+        sourceId: job.source.id,
+        databases: {
+            count: totalFiles,
+            names: processedFiles.map(f => f.database)
+        },
+        engineVersion: ctx.metadata?.engineVersion,
+        engineEdition: ctx.metadata?.engineEdition,
+        timestamp: new Date().toISOString(),
+        originalFileName: processedFiles.map(f => f.finalName).join(', '),
+        compression: (compression && compression !== 'NONE') ? compression : undefined,
+        encryption: undefined,
+        checksum: undefined,
+        multiDb: {
+            format: 'separate_files',
+            databases: processedFiles.map(f => f.database)
+        }
+    };
+
+    const manifestPath = path.join(path.dirname(processedFiles[0].finalPath), '.manifest.json');
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+    ctx.setStage(PIPELINE_STAGES.UPLOADING);
+
+    // Collect destinations that need post-upload integrity verification
+    const verifyQueue: Array<{ dest: typeof ctx.destinations[number]; destLabel: string; processedFiles: typeof processedFiles }> = [];
+
+    // Upload each file to each destination
+    for (let destIdx = 0; destIdx < totalDests; destIdx++) {
+        const dest = ctx.destinations[destIdx];
+        const destLabel = `[${dest.configName}]`;
+
+        ctx.log(`${destLabel} Starting upload of ${totalFiles} database files...`);
+
+        try {
+            for (let fileIdx = 0; fileIdx < totalFiles; fileIdx++) {
+                const procFile = processedFiles[fileIdx];
+                const uploadStart = Date.now();
+
+                const remotePath = `${job.name}/${procFile.finalName}`;
+                const destProgress = (percent: number) => {
+                    const fileProgress = (fileIdx / totalFiles) * 100;
+                    const currentFilePercent = (percent / totalFiles);
+                    const combinedPercent = Math.round(fileProgress + currentFilePercent);
+                    ctx.updateDetail(`${dest.configName} - [${fileIdx + 1}/${totalFiles}] ${procFile.database} (${percent}%)`);
+                    ctx.updateStageProgress(combinedPercent);
+                };
+
+                ctx.log(`${destLabel} Uploading ${procFile.database}: ${procFile.finalName}...`);
+
+                const uploadSuccess = await dest.adapter.upload(
+                    dest.config,
+                    procFile.finalPath,
+                    remotePath,
+                    destProgress,
+                    (msg, level, type, details) => ctx.log(`${destLabel} ${msg}`, level, type, details)
+                );
+
+                if (!uploadSuccess) {
+                    throw new Error(`Failed to upload ${procFile.finalName}`);
+                }
+
+                uploadedSuccessfully++;
+                ctx.log(`${destLabel} Uploaded: ${remotePath}`);
+            }
+
+            // Upload manifest
+            const manifestRemotePath = `${job.name}/.manifest.json`;
+            ctx.log(`${destLabel} Uploading manifest...`);
+            await dest.adapter.upload(
+                dest.config,
+                manifestPath,
+                manifestRemotePath,
+                undefined,
+                (msg, level, type, details) => ctx.log(`${destLabel} ${msg}`, level, type, details)
+            );
+
+            dest.uploadResult = { success: true, path: `${job.name}` };
+            ctx.log(`${destLabel} All files uploaded successfully`);
+
+            // Queue integrity verification for local storage
+            if (dest.adapterId === "local-filesystem") {
+                verifyQueue.push({ dest, destLabel, processedFiles });
+            }
+
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            dest.uploadResult = { success: false, error: message };
+            ctx.log(`${destLabel} Upload FAILED: ${message}`, 'error');
+        }
+    }
+
+    // Cleanup manifest and processed files
+    await fs.unlink(manifestPath).catch(() => {});
+    for (const procFile of processedFiles) {
+        await fs.unlink(procFile.finalPath).catch(() => {});
+    }
+
+    // --- POST-UPLOAD VERIFICATION ---
+    ctx.setStage(PIPELINE_STAGES.VERIFYING);
+
+    if (verifyQueue.length > 0) {
+        for (const { dest, destLabel, processedFiles: filesToVerify } of verifyQueue) {
+            try {
+                ctx.log(`${destLabel} Verifying ${filesToVerify.length} file(s) integrity...`);
+
+                for (const procFile of filesToVerify) {
+                    try {
+                        const remotePath = `${job.name}/${procFile.finalName}`;
+                        const verifyPath = path.join(getTempDir(), `verify_${Date.now()}_${procFile.finalName}`);
+
+                        const downloadOk = await dest.adapter.download(dest.config, remotePath, verifyPath);
+                        if (downloadOk && procFile.checksum) {
+                            const result = await verifyFileChecksum(verifyPath, procFile.checksum);
+                            if (result.valid) {
+                                ctx.log(`${destLabel} ${procFile.database}: Integrity check passed ✓`, 'success');
+                            } else {
+                                ctx.log(`${destLabel} ${procFile.database}: WARNING: Integrity check FAILED! Expected: ${result.expected}, Got: ${result.actual}`, 'warning');
+                            }
+                            await fs.unlink(verifyPath).catch(() => {});
+                        }
+                    } catch (e: unknown) {
+                        const message = e instanceof Error ? e.message : String(e);
+                        ctx.log(`${destLabel} ${procFile.database}: Integrity verification skipped: ${message}`, 'warning');
+                    }
+                }
+            } catch (e: unknown) {
+                const message = e instanceof Error ? e.message : String(e);
+                ctx.log(`${destLabel} Integrity verification failed: ${message}`, 'warning');
+            }
+        }
+    } else {
+        ctx.log("No local destinations - skipping integrity verification");
+    }
+
+    // Evaluate results
+    const successCount = ctx.destinations.filter(d => d.uploadResult?.success).length;
+    const failCount = ctx.destinations.filter(d => d.uploadResult && !d.uploadResult.success).length;
+
+    const firstSuccess = ctx.destinations.find(d => d.uploadResult?.success);
+    if (firstSuccess) {
+        ctx.finalRemotePath = firstSuccess.uploadResult!.path;
+    }
+
+    if (successCount === 0) {
+        throw new Error(`All ${failCount} destination upload(s) failed`);
+    }
+
+    if (failCount > 0) {
+        ctx.status = "Partial";
+        ctx.log(`Upload summary: ${successCount}/${totalDests} successful, ${failCount} failed`, 'warning');
+    } else {
+        ctx.log(`Upload summary: All ${successCount} destination(s) successful (${uploadedSuccessfully} files)`);
     }
 }

--- a/src/lib/runner/types.ts
+++ b/src/lib/runner/types.ts
@@ -48,6 +48,7 @@ export interface RunnerContext {
 
     // File paths
     tempFile?: string;
+    dumpFiles?: Array<{ path: string; name: string; database: string; size: number }>;
     finalRemotePath?: string;
 
     // Result Data

--- a/src/services/job-service.ts
+++ b/src/services/job-service.ts
@@ -20,6 +20,7 @@ export interface CreateJobInput {
     notificationIds?: string[];
     encryptionProfileId?: string;
     compression?: string;
+    multiDbBackupType?: string;
     pgCompression?: string;
     enabled?: boolean;
     notificationEvents?: string;
@@ -34,6 +35,7 @@ export interface UpdateJobInput {
     notificationIds?: string[];
     encryptionProfileId?: string;
     compression?: string;
+    multiDbBackupType?: string;
     pgCompression?: string;
     enabled?: boolean;
     notificationEvents?: string;
@@ -73,7 +75,7 @@ export class JobService {
     }
 
     async createJob(input: CreateJobInput) {
-        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, pgCompression, notificationEvents } = input;
+        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, multiDbBackupType, pgCompression, notificationEvents } = input;
 
         // Check name uniqueness
         const existingByName = await prisma.job.findFirst({ where: { name } });
@@ -90,6 +92,7 @@ export class JobService {
                 enabled: enabled !== undefined ? enabled : true,
                 encryptionProfileId: encryptionProfileId || null,
                 compression: compression || "NONE",
+                multiDbBackupType: multiDbBackupType || "SINGLE_TAR",
                 pgCompression: pgCompression ?? "",
                 notificationEvents: notificationEvents || "ALWAYS",
                 notifications: {
@@ -112,7 +115,7 @@ export class JobService {
     }
 
     async updateJob(id: string, input: UpdateJobInput) {
-        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, pgCompression, notificationEvents } = input;
+        const { name, schedule, sourceId, databases, destinations, notificationIds, enabled, encryptionProfileId, compression, multiDbBackupType, pgCompression, notificationEvents } = input;
 
         // Check name uniqueness (excluding current job)
         if (name) {
@@ -147,6 +150,7 @@ export class JobService {
                     sourceId,
                     databases: databases !== undefined ? JSON.stringify(databases) : undefined,
                     compression,
+                    multiDbBackupType,
                     pgCompression,
                     notificationEvents,
                     encryptionProfileId: encryptionProfileId === "" ? null : encryptionProfileId,


### PR DESCRIPTION
Please review everything carefully, I'm not an expert in this and I'm adding things that I think might be useful — if you don't think something is clear or necessary, feel free to discard it.
Thank you very much for your work.

## Multi-Database Backup Feature

Adds support for backing up multiple databases in two modes:

### SINGLE_TAR (default)
- All databases compressed into a single TAR archive
- Single file output, single checksum

### SEPARATE_FILES (new)
- Individual backup file per database
- Each file is independently:
  - Compressed (if configured)
  - Checksummed (SHA-256)
  - Verified post-upload (local filesystem destinations)
- Manifest file tracks all files, compression, and checksums

## Database Adapter Changes

**MySQL & MariaDB:**
- Checks multiDbBackupType config
- Returns array of files with path, name, size, and database name

**PostgreSQL:**
- Handles SINGLE_TAR (custom format with native compression)
- Handles SEPARATE_FILES (.dump files per database)
- Supports native compression (LEGACY/GZIP/LZ4/ZSTD)

**MongoDB:**
- Creates individual archive files per database
- Supports both TAR and separate files modes

**SQL Server (MSSQL):**
- Creates individual .bak files per database
- Supports both backup modes

## Upload Pipeline Enhancements (03-upload.ts)

### For SEPARATE_FILES:
1. **Compression Processing**
   - Applies GZIP/BROTLI to each file individually
   - Updates filename with compression extension
   - Logs size reduction per database

2. **Checksum Calculation**
   - SHA-256 per file after compression
   - Stored in manifest metadata

3. **Verification**
   - Post-upload integrity check for local destinations
   - Downloads and re-verifies checksum
   - Logs success/failure for each database

4. **Manifest Creation**
   - Includes compression type, checksums per file
   - Format: 'separate_files'
   - Database names and file count

## UI/Form Changes (job-form.tsx)

**Multi-Database Backup Type Selector:**
- Only visible when >1 database selected
- Options: SINGLE_TAR | SEPARATE_FILES
- Clear descriptions of each mode

**Compression Fix:**
- Fixed: isNativeCompressionActive now checks isPgSource
- PostgreSQL native compression only disables external compression for PostgreSQL
- MySQL, MongoDB, MSSQL can always use external compression (GZIP/BROTLI)

## Infrastructure

**Prisma Migration:**
- Added multiDbBackupType field to Job table
- Default: "SINGLE_TAR"

## Types & Interfaces

**RunnerContext (02-dump.ts):**
- New dumpFiles field for SEPARATE_FILES mode
- Array of {path, name, database, size}

**BackupMetadata (interfaces.ts):**
- multiDb format: 'tar' | 'separate_files'
- Per-file checksums in manifest

**BackupResult:**
- Single file mode: path + size
- Multiple files mode: files array