### PR TITLE
Add DB source filtering to prevent selection for restoration

### DIFF
--- a/src/app/dashboard/storage/restore/restore-client.tsx
+++ b/src/app/dashboard/storage/restore/restore-client.tsx
@@ -37,6 +37,7 @@ interface AdapterConfig {
     id: string;
     name: string;
     adapterId: string;
+    metadata?: string;
 }
 
 interface DbConfig {
@@ -520,6 +521,15 @@ export function RestoreClient() {
                                         <SelectContent>
                                             {sources
                                                 .filter(s => {
+                                                    // Filter out restore-excluded sources
+                                                    try {
+                                                        if (s.metadata) {
+                                                            const meta = JSON.parse(s.metadata);
+                                                            if (meta.isRestoreExcluded) return false;
+                                                        }
+                                                    } catch { }
+
+                                                    // Filter by source type compatibility
                                                     if (!file?.sourceType) return true;
                                                     const type = file.sourceType.toLowerCase();
                                                     const adapter = s.adapterId.toLowerCase();

--- a/src/components/adapter/adapter-form.tsx
+++ b/src/components/adapter/adapter-form.tsx
@@ -59,6 +59,9 @@ export function AdapterForm({ type, adapters, onSuccess, initialData, onBack }: 
     const initialMeta = initialData?.metadata ? JSON.parse(initialData.metadata) : {};
     const [healthNotificationsDisabled, setHealthNotificationsDisabled] = useState<boolean>(initialMeta.healthNotificationsDisabled === true);
 
+    // Exclude from restore (database only)
+    const [isRestoreExcluded, setIsRestoreExcluded] = useState<boolean>(initialMeta.isRestoreExcluded === true);
+
     // Credential profile assignments (Phase 4 - Generic Credential Profile System)
     const [primaryCredentialId, setPrimaryCredentialId] = useState<string | null>(initialData?.primaryCredentialId ?? null);
     const [sshCredentialId, setSshCredentialId] = useState<string | null>(initialData?.sshCredentialId ?? null);
@@ -198,7 +201,7 @@ export function AdapterForm({ type, adapters, onSuccess, initialData, onBack }: 
             // Build metadata with health notification preference for database/storage adapters
             const existingMeta = initialData?.metadata ? JSON.parse(initialData.metadata) : {};
             const metadata = (type === 'database' || type === 'storage')
-                ? { ...existingMeta, healthNotificationsDisabled }
+                ? { ...existingMeta, healthNotificationsDisabled, ...(type === 'database' ? { isRestoreExcluded } : {}) }
                 : existingMeta;
 
             const payload = {
@@ -394,6 +397,8 @@ export function AdapterForm({ type, adapters, onSuccess, initialData, onBack }: 
                         detectedVersion={detectedVersion}
                         healthNotificationsDisabled={healthNotificationsDisabled}
                         onHealthNotificationsDisabledChange={setHealthNotificationsDisabled}
+                        isRestoreExcluded={isRestoreExcluded}
+                        onIsRestoreExcludedChange={setIsRestoreExcluded}
                         primaryCredentialId={primaryCredentialId}
                         sshCredentialId={sshCredentialId}
                         onPrimaryChange={setPrimaryCredentialId}

--- a/src/components/adapter/form-sections.tsx
+++ b/src/components/adapter/form-sections.tsx
@@ -141,7 +141,7 @@ function RestoreExcludedSwitch({
             <div className="space-y-0.5">
                 <Label htmlFor="restore-excluded">Exclude from Restore</Label>
                 <p className="text-sm text-muted-foreground">
-                    This source will not appear as a restore target when recovering backups. Backups can still be created from this source.
+                    This source will not appear as a restore target when recovering backups.
                 </p>
             </div>
             <Switch

--- a/src/components/adapter/form-sections.tsx
+++ b/src/components/adapter/form-sections.tsx
@@ -54,6 +54,8 @@ interface SectionProps extends CredentialPickerHostProps {
     detectedVersion?: string | null;
     healthNotificationsDisabled?: boolean;
     onHealthNotificationsDisabledChange?: (disabled: boolean) => void;
+    isRestoreExcluded?: boolean;
+    onIsRestoreExcludedChange?: (excluded: boolean) => void;
 }
 
 /**
@@ -127,11 +129,37 @@ function HealthCheckNotificationSwitch({
     );
 }
 
+function RestoreExcludedSwitch({
+    excluded,
+    onChange,
+}: {
+    excluded: boolean;
+    onChange: (excluded: boolean) => void;
+}) {
+    return (
+        <div className="flex items-center justify-between rounded-lg border p-4">
+            <div className="space-y-0.5">
+                <Label htmlFor="restore-excluded">Exclude from Restore</Label>
+                <p className="text-sm text-muted-foreground">
+                    This source will not appear as a restore target when recovering backups. Backups can still be created from this source.
+                </p>
+            </div>
+            <Switch
+                id="restore-excluded"
+                checked={excluded}
+                onCheckedChange={onChange}
+            />
+        </div>
+    );
+}
+
 export function DatabaseFormContent({
     adapter,
     detectedVersion,
     healthNotificationsDisabled,
     onHealthNotificationsDisabledChange,
+    isRestoreExcluded,
+    onIsRestoreExcludedChange,
     primaryCredentialId,
     sshCredentialId,
     onPrimaryChange,
@@ -200,6 +228,12 @@ export function DatabaseFormContent({
                                  onChange={onHealthNotificationsDisabledChange}
                              />
                          )}
+                         {onIsRestoreExcludedChange && (
+                             <RestoreExcludedSwitch
+                                 excluded={isRestoreExcluded ?? false}
+                                 onChange={onIsRestoreExcludedChange}
+                             />
+                         )}
                      </div>
                  ) : (
                     <Tabs defaultValue="connection" className="w-full pt-2">
@@ -258,6 +292,12 @@ export function DatabaseFormContent({
                                      onChange={onHealthNotificationsDisabledChange}
                                  />
                              )}
+                             {onIsRestoreExcludedChange && (
+                                 <RestoreExcludedSwitch
+                                     excluded={isRestoreExcluded ?? false}
+                                     onChange={onIsRestoreExcludedChange}
+                                 />
+                             )}
                         </TabsContent>
                     </Tabs>
                  )}
@@ -293,6 +333,8 @@ export function DatabaseFormContent({
                 detectedVersion={detectedVersion}
                 healthNotificationsDisabled={healthNotificationsDisabled}
                 onHealthNotificationsDisabledChange={onHealthNotificationsDisabledChange}
+                isRestoreExcluded={isRestoreExcluded}
+                onIsRestoreExcludedChange={onIsRestoreExcludedChange}
                 primaryCredentialId={primaryCredentialId}
                 sshCredentialId={sshCredentialId}
                 onPrimaryChange={onPrimaryChange}
@@ -364,6 +406,12 @@ export function DatabaseFormContent({
                         onChange={onHealthNotificationsDisabledChange}
                     />
                 )}
+                {onIsRestoreExcludedChange && (
+                    <RestoreExcludedSwitch
+                        excluded={isRestoreExcluded ?? false}
+                        onChange={onIsRestoreExcludedChange}
+                    />
+                )}
             </TabsContent>
 
             {isMSSQL && (
@@ -406,6 +454,8 @@ function SshAwareTabLayout({
     detectedVersion,
     healthNotificationsDisabled,
     onHealthNotificationsDisabledChange,
+    isRestoreExcluded,
+    onIsRestoreExcludedChange,
     primaryCredentialId,
     sshCredentialId,
     onPrimaryChange,
@@ -418,6 +468,8 @@ function SshAwareTabLayout({
     detectedVersion?: string | null;
     healthNotificationsDisabled?: boolean;
     onHealthNotificationsDisabledChange?: (disabled: boolean) => void;
+    isRestoreExcluded?: boolean;
+    onIsRestoreExcludedChange?: (excluded: boolean) => void;
 } & CredentialPickerHostProps) {
     return (
         <div className="space-y-4 pt-2">
@@ -478,6 +530,12 @@ function SshAwareTabLayout({
                                 onChange={onHealthNotificationsDisabledChange}
                             />
                         )}
+                        {onIsRestoreExcludedChange && (
+                            <RestoreExcludedSwitch
+                                excluded={isRestoreExcluded ?? false}
+                                onChange={onIsRestoreExcludedChange}
+                            />
+                        )}
                     </TabsContent>
                 </Tabs>
             ) : (
@@ -513,6 +571,12 @@ function SshAwareTabLayout({
                                 type="database"
                                 disabled={healthNotificationsDisabled ?? false}
                                 onChange={onHealthNotificationsDisabledChange}
+                            />
+                        )}
+                        {onIsRestoreExcludedChange && (
+                            <RestoreExcludedSwitch
+                                excluded={isRestoreExcluded ?? false}
+                                onChange={onIsRestoreExcludedChange}
                             />
                         )}
                     </TabsContent>


### PR DESCRIPTION
Restore Exclusion Feature

Overview

The "Exclude from Restore" feature allows database sources to be excluded from the restore operation dropdown while maintaining their functionality for creating new backups.


Configuration
When creating or editing a database source, a new toggle switch "Exclude from Restore" appears in the Configuration tab. This switch lets you mark the source as unavailable for restoration purposes.

Behavior

Enabled: When the toggle is active, the source will not appear in the dropdown list when users initiate a database restore operation.

Disabled (default): The source appears normally in all restore dropdowns.
Independent: The exclusion flag only affects restore operations. The source continues to work normally for:

Creating new backups
Scheduling backup jobs
Health checks

Use Cases

Test/Development Sources: Exclude staging database sources to prevent accidental production data overwrites during restore operations.
Deprecated Sources: Hide sources that are no longer actively used without deleting them.
Safety Mechanism: Prevent users from selecting certain critical sources as restore destinations.
Technical Implementation

The exclusion flag is stored in the adapter's metadata and is checked during the source filtering process when rendering the restore dialog. The filtering is safe and handles malformed metadata gracefully.

<img width="641" height="775" alt="imagen" src="https://github.com/user-attachments/assets/3b90d9a2-9026-4cf9-804f-2ee94ba0633a" />

As before, if you don't see it as useful or necessary, feel free to discard it

Thx!