### PR TITLE
fix(ui): sync database explorer state with url parameters on back navigation

### DIFF
--- a/src/components/dashboard/explorer/database-explorer.tsx
+++ b/src/components/dashboard/explorer/database-explorer.tsx
@@ -55,6 +55,14 @@ export function DatabaseExplorer({ sources, canBrowse }: DatabaseExplorerProps) 
     const [selectedSource, setSelectedSource] = useState<string>(initialSourceId);
     const [selectedDatabase, setSelectedDatabase] = useState<string>(initialDatabase);
     const [selectedTable, setSelectedTable] = useState<string>(initialTable);
+
+    // Sync state with URL when navigating via browser back/forward buttons
+    useEffect(() => {
+        setSelectedSource(searchParams.get("sourceId") ?? "");
+        setSelectedDatabase(searchParams.get("database") ?? "");
+        setSelectedTable(searchParams.get("table") ?? "");
+    }, [searchParams]);
+
     const [databases, setDatabases] = useState<DatabaseInfo[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
Resolves #126

This PR fixes a React state synchronization bug in the Database Explorer where navigating via the browser's back or forward buttons failed to update the internal UI state.

Changes:
- Added a `useEffect` hook in `database-explorer.tsx` that listens to `useSearchParams()` and automatically updates the `selectedDatabase` and `selectedTable` component states to match the current URL parameters. This ensures full history API compatibility.